### PR TITLE
Propose revised structure for VarPath statements

### DIFF
--- a/examples/VA-ClinVar-SCV-Example-001.yaml
+++ b/examples/VA-ClinVar-SCV-Example-001.yaml
@@ -1,6 +1,4 @@
-classification:
-  label: Pathogenic
-  description: submitted as `pathologic`
+conclusion: Pathogenic
 significance: supports
 strength: strong
 condition:
@@ -62,16 +60,16 @@ extensions:
     value: 3-star
 - name: clinvar-scv-methods
   type: Extension
-  value:
-  - curation
+  value: curation
 - name: clinvar-scv-affected-statuses
   type: Extension
-  value:
-  - unknown
+  value: unknown
 - name: clinvar-scv-allele-origins
   type: Extension
-  value:
-  - germline
+  value: germline
+- name: clinvar-scv-submitter-classification
+  type: Extension
+  value: pathologic
 id: cvc-scv:SCV001949955-20220101
 method:
   id: cspec:123134

--- a/examples/VA-ClinVar-SCV-Example-001.yaml
+++ b/examples/VA-ClinVar-SCV-Example-001.yaml
@@ -1,9 +1,8 @@
 classification:
-  code: LN12331-1
   label: Pathogenic
-  system: LN
-  text: pathologic
-  type: CodeableConcept
+  description: submitted as `pathologic`
+significance: supports
+strength: strong
 condition:
   condition_set_id: clinvar-traitset_id:123
   id: ??


### PR DESCRIPTION
This PR proposes a revised structure for VarPath statements that uses the `conclusion` elements previously discussed [here](https://lucid.app/lucidchart/68dbb6e6-376a-41c6-9c27-4b463c17a963/edit?invitationId=inv_cfaa4c67-8559-498a-b742-69a4af8ff508&page=jCifsZ~duTXC#) while keeping a description field for free-text comments (e.g. submitted term)