### PR TITLE
Add VA attributes to handle 'extension' content in annotation-source.yaml

### DIFF
--- a/schema/annotation-source.yaml
+++ b/schema/annotation-source.yaml
@@ -56,6 +56,11 @@ $defs:
           - $ref: "#/$defs/Document"
           - $ref_curie: gks.core:CURIE
         description: A document in which the information content is expressed.
+      information_quality:
+        type: string
+        description: >-
+           A term indicating the scientific rigor with which the information was generated and 
+           documented for use. 
       record_metadata:
         $ref_curie: gks.core:RecordMetadata
     heritable_required: [ "id" ]
@@ -185,7 +190,23 @@ $defs:
         enum: [ "supports", "uncertain", "opposes" ]
         description: >-
           The direction of this statement with respect to the target proposition.
-
+      has_evidence_of_type: 
+        type: string
+        enum: [ "case-control evidence", "clinical testing evidence", "curation-based evidence", 
+        "author statement from literature", "phenotyping evidence", "provider interpretation evidence", 
+        "reference population evidence", "research evidence" ]
+        description: >-
+          A term describing a type of evidence used to assess the validity of Statement's proposition.          
+      statement_quality: 
+        extends: information_quality
+        type: string
+        enum: ["4-star, practice guideline", "3-star, reviewed by expert panel", "1-star, criteria provided, 
+        single submitter", "0-star, no assertion criteria provided", "0-star, no assertion provided", 
+        "0-star, no interpretation for the single variant" ]
+        description: > -
+          A qualitative term indicating the scientific rigor with which the Statement was generated and/or 
+          documented for use. 
+      
   VariationStatement:
     inherits: Statement
     description: >-

--- a/schema/annotation-source.yaml
+++ b/schema/annotation-source.yaml
@@ -59,7 +59,7 @@ $defs:
       information_quality:
         type: string
         description: >-
-           A term indicating the scientific rigor with which the information was generated and 
+           A term indicating the scientific rigor with which the information was generated and/or 
            documented for use. 
       record_metadata:
         $ref_curie: gks.core:RecordMetadata


### PR DESCRIPTION
Exploring potential to move content from two metakb-cvc extensions into proper VA fields. Lower priority IMO, but worth at least mentioning ahead of the plenary.
    - ClinVar collection method data is currently in a `clinvar-scv-methods` Extension, but could be framed to fit into the VA `Statement.has_evidence_of_type` attribute.
    - ClinVar review status is currently in a `clinvar-review-status` Extension,  but could be framed to fit into the VA `InformationEntity.information_quality` attribute. 
