### PR TITLE
Refactor evidence/confidence level/direction model in annotation-source.yaml

### DIFF
--- a/schema/annotation-source.yaml
+++ b/schema/annotation-source.yaml
@@ -26,16 +26,6 @@ $defs:
         type: string
         description: >-
           A free-text description of the InformationEntity.
-      confidence_level:
-        $ref_curie: gks.core:Coding
-        description: >-
-          A coded term describing the strength of support that the information the statement
-          represents is true.
-      confidence_score:
-        $ref: "#/$defs/DataItem"
-        description: >-
-          A quantitative score reflecting the degree of confidence that the information 
-          the information entity represents is true.
       method:
         oneOf:
         - $ref: "#/$defs/Method"
@@ -161,30 +151,51 @@ $defs:
       A Statement (aka ‘Assertion’) represents a claim of purported truth as made by a particular agent, 
       on a particular occasion.
     heritable_properties:
-      evidence_level:
-        $ref_curie: gks.core:Coding
-        description: >- 
-          A term indicating the overall strength of support for the Statement based on all evidence assessed.
-      evidence_score:
-        $ref: "#/$defs/DataItem"
-        description: >-
-          A quantitative score reflecting the overall strength of support for the Statement based on all 
-          evidence assessed.
       target_proposition:
         oneOf:
         - $ref: "#/$defs/Proposition"
         - $ref_curie: gks.core:CURIE
         description: The Proposition about which the Statement is made.
+      evidence_direction:
+         type: string
+         enum: [ "supports", "disputes", inconclusive" ] 
+         description: >-
+           A term indicating the net direction of all evidence assessed against the target proposition. 
+      evidence_level:
+        $ref_curie: gks.core:Coding
+        description: >- 
+          A term indicating the overall strength of support for or against the Statement's proposition, 
+          as provided by all evidence evaluated.
+      evidence_score:
+        $ref: "#/$defs/DataItem"
+        description: >-
+          A quantitative score reflecting the overall strength of support for or against the Statement's 
+          proposition, as provided by all evidence evaluated.
+      confidence_level: 
+        $ref_curie: gks.core:Coding
+        description: >-
+          A term indicating the asserting agent's level of confidence that the target 
+          proposition is true or false (the direction this assessment pertains to is captured
+          by the confidence_direction field).
+      confidence_score: 
+        $ref: "#/$defs/DataItem" 
+        description: >-
+          A quantitative score term reflecting the asserting agent's level of confidence that
+          the target proposition is true or false (the direction this assessment pertains to 
+          is captured by the confidence_direction attribute).
+      confidence_direction: 
+        type: string
+        enum: [ "true", "false", "uncertain" ]
+        description: >-
+          A term indicating whether the assessment reported in the confidence_level and 
+          confidence_score fields reflects confidence that the target proposition is true, 
+          or false. 
       conclusion:
         $ref_curie: gks.core:Coding
         description: >-
-          The conclusion drawn from the statement proposition, direction, strength, and/or 
-          confidence score.
-      direction:
-        type: string
-        enum: [ "supports", "uncertain", "opposes" ]
-        description: >-
-          The direction of this statement with respect to the target proposition.
+          A term that describes a final conclusion about the subject of the target proposition, 
+          based on what the proposition expresses, and assessments of confidence and/or evidence 
+          level and direction.     
 
   VariationStatement:
     inherits: Statement
@@ -237,7 +248,9 @@ $defs:
       target_proposition:
         extends: target_proposition
         $ref: "#/$defs/VariationGermlinePathogenicityProposition"
-
+      confidence_level:
+        extends: confidence_level
+        enum: [ "likely", "definitive" ]
   VariationNeoplasmStatement:
     inherits: VariationStatement
     description: >-

--- a/schema/annotation-source.yaml
+++ b/schema/annotation-source.yaml
@@ -155,10 +155,11 @@ $defs:
         oneOf:
         - $ref: "#/$defs/Proposition"
         - $ref_curie: gks.core:CURIE
-        description: The Proposition about which the Statement is made.
+        description: The Proposition assessed by the author of the Statement, and about which the Statement
+        is made.
       evidence_direction:
          type: string
-         enum: [ "supports", "disputes", inconclusive" ] 
+         enum: [ "supports", "disputes", "inconclusive" ] 
          description: >-
            A term indicating the net direction of all evidence assessed against the target proposition. 
       evidence_level:


### PR DESCRIPTION
This PR proposes to update the representation of evidence and confidence levels/directions to align with the VA 'PropositionAssessment' model [documented here](https://docs.google.com/document/d/18vBMg6nl7S1rAUCSoybo8ONeNGK5ObuV2WhDhZJBmLg/edit?pli=1#heading=h.4n73i6edie6q), which we discussed at the end of the most recent VA call.
- Removes `confidence_level` and `confidence_score` from InformationEntity (per discussion [here](https://github.com/ga4gh/va-spec/issues/84)) - and moves them into Statement
- Defines two trios of properties in the Statement class to represent assessments of evidence and confidence in the target proposition - to makes it very clear what aspect of the target proposition is being assessed and how. (Note that trios to support confidence assessments and evidence assessments are needed because cvc data does the former, and metakb data does the latter . . . but within any one Statement subtype adopters can chose either, both, or neither trio).
    - `evidence_level`, `evidence_score`, `evidence_direction` -> used to describe evidence assessments
    - `confidence_level`, `confidence_score`, `confidence_direction` -> used to describe confidence assessments
- Proposes enumerations for values of direction and level attributes in the Statement class.
- Proposes a specific enumeration for values of  confidence_level in the VariationGermlinePathogenicityStatement class

 I also created this [this data example](https://github.com/ga4gh/va-spec/blob/master/docs/Modeling/SCV001949955_mhb_version_of_cvc_model_20220809.yml), to illustrate the model and its application to ClinVar data more concretely. We can discuss in more detail when we next meet.

_FWIW, I find that it can be hard to see the forest for the trees when trying to negotiate diffs and comments in the 'Conversation' and 'Files Changed' views of a PR - and always start by looking at the [updated file directly](https://github.com/ga4gh/va-spec/blob/a65fc7e1b7f1f56207d4e09d0b551eb88d6bf240/schema/annotation-source.yaml#L148) (then go back to look at diffs and comments)._
