### PR TITLE
Added 'qualifier' back to core-im-source.yaml

### DIFF
--- a/schema/va-spec/core-im/core-im-source.yaml
+++ b/schema/va-spec/core-im/core-im-source.yaml
@@ -103,6 +103,13 @@ $defs:
         description: The predicate of the Statement.
       object:
         description: The object of the Statement.
+      qualifier:
+        description: >-
+          An additional piece of information that extends or refines the meaning of the core 
+          subject-predicate-object 'triple' - by providing additional detail, or constraining 
+          the statement to apply in a particular context.
+        type: object
+        additionalProperties: false
       direction:
         type: string
         enum:
@@ -138,7 +145,7 @@ $defs:
         description: >-
           A single term or phrase summarizing the outcome of direction and strength
           assessments of a Statement's proposition, in terms of a classification of the
-          Statement subject. Permissible values for this attribute are typically
+          Statement's subject. Permissible values for this attribute are typically
           selected to be succinct and familiar in the target community of practice. e.g.
           'likely pathogenic' in the domain of variant pathogenicity classification'.
       hasEvidenceOfType:

--- a/schema/va-spec/core-im/core-im-source.yaml
+++ b/schema/va-spec/core-im/core-im-source.yaml
@@ -103,18 +103,25 @@ $defs:
         description: The predicate of the Statement.
       object:
         description: The object of the Statement.
-      qualifier:
-        type: object
-        description: >-
-          An additional piece of information that extends or refines the meaning of the core 
-          subject-predicate-object 'triple' - by providing additional details, precision, or 
-          constraining the statement to apply in a particular context.
-        comment: >-
-          Note that in profiles of the Statement class, 'qualifier' is typically specialized into one
-          or more properties that are defined to capture a specifc kind of qualifying information.
-          e.g.'modeOfInheritanceQualifier' and 'geneContextQualifier' in a VariantPathogenicityStatement 
-          profile.
-        additionalProperties: false
+        
+#  Commenting out the 'qualifier' property for now to aviod its unwanted inheritance in Statement profiles.
+#  Ww will re-instate this property once we determine if/how the metaschema processer can evolve to support
+#  the use case described in the 'comment' below, and discussed in va-spec issue #134.
+#
+#     qualifier:
+#       type: object
+#       description: >-
+#         An additional piece of information that extends or refines the meaning of the core 
+#         subject-predicate-object 'triple' - by providing additional details, precision, or 
+#         constraining the statement to apply in a particular context.
+#       comment: >-
+#         Note that this qualifier property is a 'placeholder' that should not be inherited or used 
+#         as is in dervied Statement profiles. It is meant to be specialized into more specifc properties
+#         that are defined to capture a specifc kind of qualifying information relevant to a particular 
+#         Statement profile. e.g. for a VariantPathogenicityStatement, it is specalized into 
+#        'modeOfInheritanceQualifier' and 'geneContextQualifier' properties.  
+#       additionalProperties: false
+
       direction:
         type: string
         enum:

--- a/schema/va-spec/core-im/core-im-source.yaml
+++ b/schema/va-spec/core-im/core-im-source.yaml
@@ -104,11 +104,16 @@ $defs:
       object:
         description: The object of the Statement.
       qualifier:
+        type: object
         description: >-
           An additional piece of information that extends or refines the meaning of the core 
-          subject-predicate-object 'triple' - by providing additional detail, or constraining 
-          the statement to apply in a particular context.
-        type: object
+          subject-predicate-object 'triple' - by providing additional details, precision, or 
+          constraining the statement to apply in a particular context.
+        comment: >-
+          Note that in profiles of the Statement class, 'qualifier' is typically specialized into one
+          or more properties that are defined to capture a specifc kind of qualifying information.
+          e.g.'modeOfInheritanceQualifier' and 'geneContextQualifier' in a VariantPathogenicityStatement 
+          profile.
         additionalProperties: false
       direction:
         type: string

--- a/schema/va-spec/core-im/core-im-source.yaml
+++ b/schema/va-spec/core-im/core-im-source.yaml
@@ -103,24 +103,23 @@ $defs:
         description: The predicate of the Statement.
       object:
         description: The object of the Statement.
-        
-#  Commenting out the 'qualifier' property for now to aviod its unwanted inheritance in Statement profiles.
+
+#  Note that the `qualifier` property below is a *placeholder* that should not be inherited or used 
+#  as is in dervied Statement profiles. It is meant to be specialized into more specifc properties
+#  that are defined to capture a specifc kind of qualifying information relevant to a particular 
+#  Statement profile. e.g. for a VariantPathogenicityStatement, it is specalized into 
+#  'modeOfInheritanceQualifier' and 'geneContextQualifier' properties. 
+#  Commenting out this property for now to aviod its unwanted inheritance in Statement profiles.
 #  Ww will re-instate this property once we determine if/how the metaschema processer can evolve to support
 #  the use case described in the 'comment' below, and discussed in va-spec issue #134.
 #
 #     qualifier:
 #       type: object
+#       placeholder: true      # example of what a flag on core-im properties meant to be placeholders might look like
 #       description: >-
 #         An additional piece of information that extends or refines the meaning of the core 
 #         subject-predicate-object 'triple' - by providing additional details, precision, or 
 #         constraining the statement to apply in a particular context.
-#       comment: >-
-#         Note that this qualifier property is a 'placeholder' that should not be inherited or used 
-#         as is in dervied Statement profiles. It is meant to be specialized into more specifc properties
-#         that are defined to capture a specifc kind of qualifying information relevant to a particular 
-#         Statement profile. e.g. for a VariantPathogenicityStatement, it is specalized into 
-#        'modeOfInheritanceQualifier' and 'geneContextQualifier' properties.  
-#       additionalProperties: false
 
       direction:
         type: string


### PR DESCRIPTION
Larry dropped this in he latest refactor. But IMO defining `qualifier` in the core-im is important for two reasons. It is useful to explain what the notion of a ‘qualifier’ means and what it is used for in the modeling framework. And it is necessary to implement the conceptual specialization I describe above, which  happens when a specific qualifier property is defined in a Statement profile.

in this PR:
-  'qualifier' is named using the singular name - consistent with it not taking an array in the core-im, and supporting the allowed 1:m specialization that is done when profiling this property. 
- the property takes ‘object’  (which by my understanding covers any data type, including string, enums, IRIs, or nested/referenced structured objects)
- I gave it a clear and informative free-text description, and added a ‘comment’ that explains how this property can get profiled into >1 more specific qualifier properties
