### PR TITLE
Update qualifier text descriptions in VarPath profile

### DIFF
--- a/schema/va-spec/profiles/profiles-source.yaml
+++ b/schema/va-spec/profiles/profiles-source.yaml
@@ -264,8 +264,9 @@ $defs:
         - low
         - risk allele
         description: >-
-          The extent to which the variant impact is expressed by individuals carrying it as
-          a measure of the proportion of carriers exhibiting the condition.
+          Extends the statement to report the penetrance of the pathogenic effect - i.e. the extent 
+          to which the variant impact is expressed by individuals carrying it as a measure of the 
+          proportion of carriers exhibiting the condition.
       modeOfInheritanceQualifier:
         type: string
         enum:
@@ -275,9 +276,11 @@ $defs:
         - X-linked recessive
         - mitochondrial
         description: >-
-          The pattern of inheritance expected for the pathogenic effect of this variant.
+          Reports a pattern of inheritance expected for the pathogenic effect of the variant. 
       geneContextQualifier:
-        description: A gene context that qualifies the Statement.
+        description: >-
+          Reports the gene through which the pathogenic effect asserted for the variant is mediated 
+          (i.e. it is the variant's impact on this gene that is responsible for causing the condition).
         $refCurie: gks.domain-entities:Gene
     required:
     - subjectVariant


### PR DESCRIPTION
Updated the free-text descriptions of Var Path qualifier properties, to more clearly frame how they extend/refine/contextualize the statement expressed by the core S-P-O triple.  

Framing qualifier definitions in this way will help users better understand how to interpret the info they holds, and correctly piece together the full semantics of the statement being made.