### PR TITLE
Update qualifier modeling in Therapeutic Response profile

### DIFF
--- a/schema/va-spec/profiles/profiles-source.yaml
+++ b/schema/va-spec/profiles/profiles-source.yaml
@@ -322,7 +322,7 @@ $defs:
       alleleOriginQualifier:
         type: string
         description: >-
-          Whether the statement should be interpreted in the context of an inherited
+          Reports whether the statement should be interpreted in the context of an inherited
           (germline) variant, an acquired (somatic) mutation, or both (combined).
         enum:
         - germline
@@ -331,7 +331,7 @@ $defs:
       allelePrevalenceQualifier:
         type: string
         description: >-
-          Whether the statement should be interpreted in the context of the variant
+          Reports whether the statement should be interpreted in the context of the variant
           being rare or common.
         enum:
         - rare
@@ -378,18 +378,18 @@ $defs:
         oneOf:
         - $refCurie: gks.domain-entities:TherapeuticProcedure
         - $refCurie: gks.core:IRI
-      disease:
+      diseaseQualifier:
         oneOf:
         - $refCurie: gks.domain-entities:Condition
         - $refCurie: gks.core:IRI
-        description: The disease context in which the variant impact is evaluated.
-      isReportedIn:
-        extends: isReportedIn
-        minItems: 1
+        description: >-
+          Reports the disease context in which the variant's association with therapeutic 
+          sensitivity or resistance is evaluated. Note that this is a required qualifier in 
+          therapeutic response statements.
       alleleOriginQualifier:
         type: string
         description: >-
-          Whether the statement should be interpreted in the context of an inherited
+          Reports whether the statement should be interpreted in the context of an inherited
           (germline) variant, an acquired (somatic) mutation, or both (combined).
         enum:
           - germline
@@ -398,16 +398,22 @@ $defs:
       allelePrevalenceQualifier:
         type: string
         description: >-
-          Whether the statement should be interpreted in the context of the variant
+         Reports wWhether the statement should be interpreted in the context of the variant
           being rare or common.
         enum:
           - rare
           - common
       geneContextQualifier:
-        description: A gene context that qualifies the Statement.
+        description: >
+          Reports a gene impacted by the variant, which contributes to the therapeutic 
+          sensitivity or resistance reported in the Statement. 
         $refCurie: gks.domain-entities:Gene
+      isReportedIn:
+        extends: isReportedIn
+        minItems: 1
     required:
     - subjectVariant
     - predicate
     - objectTherapeutic
+    - diseaseQualifier
     - isReportedIn


### PR DESCRIPTION
Several changes made:
- Appends “Qualifier” to the `disease` property --> `diseaeQualifier`
    - conceptually / semantically this information fits the qualifier definition (it adds additional info/context to the core SPO triple to express the full meaning of the Statement - which will read "VariantX _predictesSensitivityTo_ TherapeuticY in the context of Disease Z"). 
    - also, the original motivation for not framing this as a qualifier (which was to separate it from non-required qualifiers that were previously nested in a Qualifiers object) no longer applies - because we now have a flat list of top level qualifier properties and can directly state `diseaseQualifier` to be required while leaving the other qualifiers as optional.
- Makes `diseaseQualifier` a required property (this was expressed to me as the intent – feel free to change back if not)
- Provided clearer definitions of all TherapeuticResponseStatement qualifier properties - that better frame how they refine/extend/contextualize the statement expressed in the core S-P-O triple.