### PR TITLE
Update StudyResult.dataItem property

### DIFF
--- a/schema/va-spec/core-im/core-im-source.yaml
+++ b/schema/va-spec/core-im/core-im-source.yaml
@@ -187,14 +187,18 @@ $defs:
         description: >-
           The specific subject or experimental unit in a Study that data in the StudyResult object is about.
           e.g. a particular variant in a population allele frequency dataset like ExAC or gnomAD.
-      dataItems:
-        type: array
-        ordered: false
-        items:
-          $ref: "#/$defs/DataItem"
+      dataItem:
+        type: object
+        additionalProperties: false
         description: >-
-          A Data Item  that is included in the StudyResult because it pertains to the entity that is the 'focus'.
-          This data can directly describe this focus, or represent metadata about data in the Result were generated.
+          An item of data that is included in the StudyResult because it pertains to the 'focus' of the result.
+          This data can directly describe this 'focus' (e.g. the population frequency of an allele focus), or 
+          represent metadata about how data about the 'focus' were generated (e.g the sequencing method used to 
+          determine this allele frequency).
+        comment: >-
+          Note that in profiles of the StudyResult class, 'dataItem' is typically specialized into one or more 
+          datatype-specific properties that are defined to capture a specifc kind of data. e.g. 'focusAlleleCount'
+          and 'focusAlleleFrequency' in a CohortAlleleFrequencyStudyResult profile.
       sourceDataSet:
         extends: derivedFrom
         items:


### PR DESCRIPTION
Here I update StudyResult.dataItem property to align with analogous paradigm for qualifier specialization

### Background and Motivation
In issue #134 @larrybabb  proposed that profiles can define specific qualifiers as ‘new’ properties as long as they are named as qualifiers.  @mbrush clarified that these are not truly ‘new’ – as conceptually they specialize the core-im `Statement.qualifier` property. 

The use of `StudyResult.dataItem` property in StudyResult profiles is quite analogous, in that profiling often requires defining >1 specialization of this property for different specific data types. 

### Changes
In this PR, we update the definition of StudyResult.dataItem in the core-im to support this paradigm and align with how `Statement.qualifier` is defined in PR #160

Specifically: 
- removed the existing `dataItems` property
- replaced it with a ‘dataItem’ property (singular, consistent with it not taking an array in the core-im)
- made it take an ‘object’  (which by my understanding covers strings)
- gave it a clear and informative free-text description
- added a ‘comment’ that explains how this property can get profiled into >1 more specific properties. 

In the future we might consider some type of flag/keyword on this core-im property to explicitly mark it as amenable to 1:m specialization in profiles – if this helps with conceptual clarity or computational validation.