### PR TITLE
alignment cleanup

### DIFF
--- a/schema/va-spec/core-im/core-im-source.yaml
+++ b/schema/va-spec/core-im/core-im-source.yaml
@@ -360,23 +360,23 @@ $defs:
       #     the option of encapsulating the structured semantics of the possible fact asserted or
       #     evaluated by a Statement in a separate 'Proposition' object - instead of using the subject,
       #     predicate, object, qualifier properties directly in the Statement object.
-      subjectClassification:
+      classification:
         oneOf:
           - $refCurie: gks.common:Coding
           - $refCurie: gks.common:IRI
         description: >-
           A single term or phrase summarizing the outcome of direction and strength
-          assessments of a Statement's proposition, in terms of a classification of the
-          Statement's subject. Permissible values for this attribute are typically
-          selected to be succinct and familiar in the target community of practice. e.g.
-          'likely pathogenic' in the domain of variant pathogenicity classification'.
+          assessments of a Statement, in terms of a classification of the Statement's
+          subject. Permissible values for this attribute are typically selected to be
+          succinct and familiar in the target community of practice. e.g. 'likely pathogenic'
+          in the domain of variant pathogenicity classification'.
       hasEvidenceOfType:
         type: array
         ordered: false
         items:
           $refCurie: gks.common:Coding
         description: >-
-          A term describing a type of evidence used to assess the validity of Statement's proposition
+          A term describing a type of evidence used to assess the validity of Statement
           (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
       hasEvidenceLines:
         type: array
@@ -384,9 +384,8 @@ $defs:
         items:
           $ref: "#/$defs/EvidenceLine"
         description: >-
-          A discrete, independent argument relevant to the validity of the Proposition assessed or
-          put forth in the Statement. This argument is based on the interpretation of one or more
-          pieces of information as evidence.
+          A discrete, independent argument relevant to the validity put forth in the Statement. This
+          argument is based on the interpretation of one or more pieces of information as evidence.
       hasEvidence:
         type: array
         ordered: false

--- a/schema/va-spec/core-im/def/Statement.rst
+++ b/schema/va-spec/core-im/def/Statement.rst
@@ -88,18 +88,18 @@ Some Statement attributes are inherited from :ref:`InformationEntity`.
           - string
           - 0..1
           - A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, "BRCA2 c.8023A>G is pathogenic for Breast Cancer", or "there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer".
-       *  - subjectClassification
+       *  - classification
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_ | `IRI <../../gks-common/common-source.json#/$defs/IRI>`_
           - 0..1
-          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
+          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
        *  - hasEvidenceOfType
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_
           - 0..m
-          - A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
+          - A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
        *  - hasEvidenceLines
           - :ref:`EvidenceLine`
           - 0..m
-          - A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
+          - A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
        *  - hasEvidence
           - :ref:`InformationEntity`
           - 0..m

--- a/schema/va-spec/profiles/def/VariantDiagnosticStudyStatement.rst
+++ b/schema/va-spec/profiles/def/VariantDiagnosticStudyStatement.rst
@@ -72,18 +72,18 @@ Some VariantDiagnosticStudyStatement attributes are inherited from :ref:`va.core
           - string
           - 0..1
           - A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, "BRCA2 c.8023A>G is pathogenic for Breast Cancer", or "there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer".
-       *  - subjectClassification
+       *  - classification
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_ | `IRI <../../gks-common/common-source.json#/$defs/IRI>`_
           - 0..1
-          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
+          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
        *  - hasEvidenceOfType
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_
           - 0..m
-          - A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
+          - A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
        *  - hasEvidenceLines
           - `EvidenceLine <../core-im/core.json#/$defs/EvidenceLine>`_
           - 0..m
-          - A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
+          - A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
        *  - hasEvidence
           - `InformationEntity <../core-im/core.json#/$defs/InformationEntity>`_
           - 0..m

--- a/schema/va-spec/profiles/def/VariantOncogenicityStudyStatement.rst
+++ b/schema/va-spec/profiles/def/VariantOncogenicityStudyStatement.rst
@@ -72,18 +72,18 @@ Some VariantOncogenicityStudyStatement attributes are inherited from :ref:`va.co
           - string
           - 0..1
           - A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, "BRCA2 c.8023A>G is pathogenic for Breast Cancer", or "there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer".
-       *  - subjectClassification
+       *  - classification
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_ | `IRI <../../gks-common/common-source.json#/$defs/IRI>`_
           - 0..1
-          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
+          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
        *  - hasEvidenceOfType
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_
           - 0..m
-          - A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
+          - A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
        *  - hasEvidenceLines
           - `EvidenceLine <../core-im/core.json#/$defs/EvidenceLine>`_
           - 0..m
-          - A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
+          - A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
        *  - hasEvidence
           - `InformationEntity <../core-im/core.json#/$defs/InformationEntity>`_
           - 0..m

--- a/schema/va-spec/profiles/def/VariantPathogenicityStatement.rst
+++ b/schema/va-spec/profiles/def/VariantPathogenicityStatement.rst
@@ -72,18 +72,18 @@ Some VariantPathogenicityStatement attributes are inherited from :ref:`va.core:S
           - string
           - 0..1
           - A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, "BRCA2 c.8023A>G is pathogenic for Breast Cancer", or "there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer".
-       *  - subjectClassification
+       *  - classification
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_ | `IRI <../../gks-common/common-source.json#/$defs/IRI>`_
           - 0..1
-          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
+          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
        *  - hasEvidenceOfType
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_
           - 0..m
-          - A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
+          - A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
        *  - hasEvidenceLines
           - `EvidenceLine <../core-im/core.json#/$defs/EvidenceLine>`_
           - 0..m
-          - A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
+          - A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
        *  - hasEvidence
           - `InformationEntity <../core-im/core.json#/$defs/InformationEntity>`_
           - 0..m
@@ -116,7 +116,3 @@ Some VariantPathogenicityStatement attributes are inherited from :ref:`va.core:S
           - `Gene <../../gks-domain-entities/domain-entities.json#/$defs/Gene>`_
           - 0..1
           - Reports the gene through which the pathogenic effect asserted for the variant is mediated (i.e. it is the variant's impact on this gene that is responsible for causing the condition).
-       *  - classification
-          - `Coding <../../gks-common/common.json#/$defs/Coding>`_ | `IRI <../../gks-common/common.json#/$defs/IRI>`_
-          - 0..1
-          - A methodological, summary classification about the impact of a variant.

--- a/schema/va-spec/profiles/def/VariantPrognosticStudyStatement.rst
+++ b/schema/va-spec/profiles/def/VariantPrognosticStudyStatement.rst
@@ -72,18 +72,18 @@ Some VariantPrognosticStudyStatement attributes are inherited from :ref:`va.core
           - string
           - 0..1
           - A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, "BRCA2 c.8023A>G is pathogenic for Breast Cancer", or "there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer".
-       *  - subjectClassification
+       *  - classification
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_ | `IRI <../../gks-common/common-source.json#/$defs/IRI>`_
           - 0..1
-          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
+          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
        *  - hasEvidenceOfType
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_
           - 0..m
-          - A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
+          - A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
        *  - hasEvidenceLines
           - `EvidenceLine <../core-im/core.json#/$defs/EvidenceLine>`_
           - 0..m
-          - A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
+          - A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
        *  - hasEvidence
           - `InformationEntity <../core-im/core.json#/$defs/InformationEntity>`_
           - 0..m

--- a/schema/va-spec/profiles/def/VariantTherapeuticResponseStudyStatement.rst
+++ b/schema/va-spec/profiles/def/VariantTherapeuticResponseStudyStatement.rst
@@ -72,18 +72,18 @@ Some VariantTherapeuticResponseStudyStatement attributes are inherited from :ref
           - string
           - 0..1
           - A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, "BRCA2 c.8023A>G is pathogenic for Breast Cancer", or "there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer".
-       *  - subjectClassification
+       *  - classification
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_ | `IRI <../../gks-common/common-source.json#/$defs/IRI>`_
           - 0..1
-          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
+          - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'.
        *  - hasEvidenceOfType
           - `Coding <../../gks-common/common-source.json#/$defs/Coding>`_
           - 0..m
-          - A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
+          - A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence').
        *  - hasEvidenceLines
           - `EvidenceLine <../core-im/core.json#/$defs/EvidenceLine>`_
           - 0..m
-          - A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
+          - A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence.
        *  - hasEvidence
           - `InformationEntity <../core-im/core.json#/$defs/InformationEntity>`_
           - 0..m

--- a/schema/va-spec/profiles/json/VariantDiagnosticStudyStatement
+++ b/schema/va-spec/profiles/json/VariantDiagnosticStudyStatement
@@ -109,7 +109,7 @@
          "type": "string",
          "description": "A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, \"BRCA2 c.8023A>G is pathogenic for Breast Cancer\", or \"there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer\"."
       },
-      "subjectClassification": {
+      "classification": {
          "oneOf": [
             {
                "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
@@ -118,7 +118,7 @@
                "$ref": "/ga4gh/schema/gks-common/1.x/json/IRI"
             }
          ],
-         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
+         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
       },
       "hasEvidenceOfType": {
          "type": "array",
@@ -126,7 +126,7 @@
          "items": {
             "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
          },
-         "description": "A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
+         "description": "A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
       },
       "hasEvidenceLines": {
          "type": "array",
@@ -134,7 +134,7 @@
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.x/core-im/json/EvidenceLine"
          },
-         "description": "A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
+         "description": "A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
       },
       "hasEvidence": {
          "type": "array",

--- a/schema/va-spec/profiles/json/VariantOncogenicityStudyStatement
+++ b/schema/va-spec/profiles/json/VariantOncogenicityStudyStatement
@@ -109,7 +109,7 @@
          "type": "string",
          "description": "A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, \"BRCA2 c.8023A>G is pathogenic for Breast Cancer\", or \"there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer\"."
       },
-      "subjectClassification": {
+      "classification": {
          "oneOf": [
             {
                "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
@@ -118,7 +118,7 @@
                "$ref": "/ga4gh/schema/gks-common/1.x/json/IRI"
             }
          ],
-         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
+         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
       },
       "hasEvidenceOfType": {
          "type": "array",
@@ -126,7 +126,7 @@
          "items": {
             "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
          },
-         "description": "A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
+         "description": "A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
       },
       "hasEvidenceLines": {
          "type": "array",
@@ -134,7 +134,7 @@
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.x/core-im/json/EvidenceLine"
          },
-         "description": "A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
+         "description": "A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
       },
       "hasEvidence": {
          "type": "array",

--- a/schema/va-spec/profiles/json/VariantPathogenicityStatement
+++ b/schema/va-spec/profiles/json/VariantPathogenicityStatement
@@ -109,7 +109,7 @@
          "type": "string",
          "description": "A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, \"BRCA2 c.8023A>G is pathogenic for Breast Cancer\", or \"there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer\"."
       },
-      "subjectClassification": {
+      "classification": {
          "oneOf": [
             {
                "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
@@ -118,7 +118,7 @@
                "$ref": "/ga4gh/schema/gks-common/1.x/json/IRI"
             }
          ],
-         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
+         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
       },
       "hasEvidenceOfType": {
          "type": "array",
@@ -126,7 +126,7 @@
          "items": {
             "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
          },
-         "description": "A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
+         "description": "A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
       },
       "hasEvidenceLines": {
          "type": "array",
@@ -134,7 +134,7 @@
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.x/core-im/json/EvidenceLine"
          },
-         "description": "A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
+         "description": "A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
       },
       "hasEvidence": {
          "type": "array",
@@ -203,17 +203,6 @@
       "geneContextQualifier": {
          "description": "Reports the gene through which the pathogenic effect asserted for the variant is mediated (i.e. it is the variant's impact on this gene that is responsible for causing the condition).",
          "$ref": "/ga4gh/schema/gks-domain-entities/1.x/json/Gene"
-      },
-      "classification": {
-         "description": "A methodological, summary classification about the impact of a variant.",
-         "oneOf": [
-            {
-               "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
-            },
-            {
-               "$ref": "/ga4gh/schema/gks-common/1.x/json/IRI"
-            }
-         ]
       }
    },
    "required": [

--- a/schema/va-spec/profiles/json/VariantPrognosticStudyStatement
+++ b/schema/va-spec/profiles/json/VariantPrognosticStudyStatement
@@ -109,7 +109,7 @@
          "type": "string",
          "description": "A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, \"BRCA2 c.8023A>G is pathogenic for Breast Cancer\", or \"there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer\"."
       },
-      "subjectClassification": {
+      "classification": {
          "oneOf": [
             {
                "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
@@ -118,7 +118,7 @@
                "$ref": "/ga4gh/schema/gks-common/1.x/json/IRI"
             }
          ],
-         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
+         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
       },
       "hasEvidenceOfType": {
          "type": "array",
@@ -126,7 +126,7 @@
          "items": {
             "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
          },
-         "description": "A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
+         "description": "A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
       },
       "hasEvidenceLines": {
          "type": "array",
@@ -134,7 +134,7 @@
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.x/core-im/json/EvidenceLine"
          },
-         "description": "A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
+         "description": "A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
       },
       "hasEvidence": {
          "type": "array",

--- a/schema/va-spec/profiles/json/VariantTherapeuticResponseStudyStatement
+++ b/schema/va-spec/profiles/json/VariantTherapeuticResponseStudyStatement
@@ -109,7 +109,7 @@
          "type": "string",
          "description": "A natural-language expression of what a structured Statement object asserts to be true. e.g. for a Variant Pathogenicity statement, \"BRCA2 c.8023A>G is pathogenic for Breast Cancer\", or \"there is moderate evidence supporting the pathogenicity of BRCA2 c.8023A>G for Breast Cancer\"."
       },
-      "subjectClassification": {
+      "classification": {
          "oneOf": [
             {
                "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
@@ -118,7 +118,7 @@
                "$ref": "/ga4gh/schema/gks-common/1.x/json/IRI"
             }
          ],
-         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's proposition, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
+         "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement, in terms of a classification of the Statement's subject. Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice. e.g. 'likely pathogenic' in the domain of variant pathogenicity classification'."
       },
       "hasEvidenceOfType": {
          "type": "array",
@@ -126,7 +126,7 @@
          "items": {
             "$ref": "/ga4gh/schema/gks-common/1.x/json/Coding"
          },
-         "description": "A term describing a type of evidence used to assess the validity of Statement's proposition (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
+         "description": "A term describing a type of evidence used to assess the validity of Statement (e.g. 'sequence similarity evidence', 'in vitro assay evidence')."
       },
       "hasEvidenceLines": {
          "type": "array",
@@ -134,7 +134,7 @@
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.x/core-im/json/EvidenceLine"
          },
-         "description": "A discrete, independent argument relevant to the validity of the Proposition assessed or put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
+         "description": "A discrete, independent argument relevant to the validity put forth in the Statement. This argument is based on the interpretation of one or more pieces of information as evidence."
       },
       "hasEvidence": {
          "type": "array",

--- a/schema/va-spec/profiles/profiles-source.yaml
+++ b/schema/va-spec/profiles/profiles-source.yaml
@@ -283,11 +283,6 @@ $defs:
           Reports the gene through which the pathogenic effect asserted for the variant is mediated
           (i.e. it is the variant's impact on this gene that is responsible for causing the condition).
         $refCurie: gks.domain-entities:Gene
-      classification:
-        description: A methodological, summary classification about the impact of a variant.
-        oneOf:
-        - $refCurie: gks.common:Coding
-        - $refCurie: gks.common:IRI
     required:
     - subjectVariant
     - predicate

--- a/tests/fixtures/VA-ClinVar-SCV-Example-001.yaml
+++ b/tests/fixtures/VA-ClinVar-SCV-Example-001.yaml
@@ -43,7 +43,7 @@ strength:
   code: cg000021
   label: Definitive (ACMG 2015)
   system: https://dataexchange.clinicalgenome.org/codes/
-subjectClassification:
+classification:
   code: cg000001
   label: Pathogenic (ACMG 2015)
   system: https://dataexchange.clinicalgenome.org/codes/
@@ -77,3 +77,6 @@ extensions:
   value: literature only
 - name: clinvarReviewStatus
   value: no assertion criteria provided
+- name: clinvarSubmittedClassification
+  value: Pathogenic
+  

--- a/tests/fixtures/VA-ClinVar-SCV-Example-002.yaml
+++ b/tests/fixtures/VA-ClinVar-SCV-Example-002.yaml
@@ -17,7 +17,7 @@ strength:
   code: cg000022
   label: Likely (ACMG 2015)
   system: https://dataexchange.clinicalgenome.org/codes/
-subjectClassification:
+classification:
   code: cg000002
   label: Likely Pathogenic (ACMG 2015)
   system: https://dataexchange.clinicalgenome.org/codes/
@@ -70,3 +70,5 @@ extensions:
   value: curation
 - name: clinvarReviewStatus
   value: reviewed by expert panel
+- name: clinvarSubmittedClassification
+  value: Likely pathogenic


### PR DESCRIPTION
* removed comment references to `proposition` which is currently out of scope.
* rename `subjectClassification` to `classification` since it is a statement-level field not specific to subject
* remove unnecessary extra `classification` field left over from prior commit.