### PR TITLE
Update caf-study-result-source.yaml

### DIFF
--- a/schema/profiles/caf-study-result-source.yaml
+++ b/schema/profiles/caf-study-result-source.yaml
@@ -58,5 +58,5 @@ $defs:
     - focusAllele
     - focusAlleleCount
     - locusAlleleCount
-    - alleleFrequency
+    - focusAlleleFrequency
     - cohort

--- a/schema/profiles/caf-study-result-source.yaml
+++ b/schema/profiles/caf-study-result-source.yaml
@@ -40,7 +40,7 @@ $defs:
         description: >-
           The number of occurrences of all alleles at the locus in the cohort 
           (sometimes referred to as "allele number")
-      alleleFrequency:
+      focusAlleleFrequency:
         type: number
         description: The frequency of the focusAllele in the cohort.
       cohort:

--- a/schema/profiles/caf-study-result-source.yaml
+++ b/schema/profiles/caf-study-result-source.yaml
@@ -1,6 +1,6 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
 $id: "https://w3id.org/ga4gh/schema/va-spec/1.x/profiles/caf-study-result-source.yaml"
-title: VA Spec Cohort Allele Frequency (population frequency) study result Standard Profiles
+title: VA Spec Cohort Allele Frequency (population frequency) Study Result Standard Profile
 strict: true
 
 imports:
@@ -31,27 +31,27 @@ $defs:
         - $ref: "/ga4gh/schema/vrs/2.x/json/Allele"
         - type: string
           format: uri-reference
-          description: The Allele for which the frequency is being reported.
+          description: The Allele for which frequency results are reported.
       focusAlleleCount:
         type: integer
         description: The number of occurrences of the focusAllele in the cohort.
       locusAlleleCount:
         type: integer
         description: >-
-          The number of occurrences of alleles at the locus in the cohort
-          (count of all alleles at this locus, sometimes referred to as "allele number")
+          The number of occurrences of all alleles at the locus in the cohort 
+          (sometimes referred to as "allele number")
       alleleFrequency:
         type: number
         description: The frequency of the focusAllele in the cohort.
-      cohortStudyGroup:
+      cohort:
         extends: studyGroup
         description: The cohort from which the frequency was derived.
       subCohortFrequency:
+        extends: componentResult
         description: >-
           A list of CohortAlleleFrequency objects describing subcohorts of the cohort currently being described.
           This creates a recursive relationship and subcohorts can be further subdivided into more subcohorts.
           This enables, for example, the description of different ancestry groups and sexes among those ancestry groups.
-        extends: componentResult
         items:
           $ref: "#/$defs/CohortAlleleFrequencyStudyResult"
     required:
@@ -59,4 +59,4 @@ $defs:
     - focusAlleleCount
     - locusAlleleCount
     - alleleFrequency
-    - cohortStudyGroup
+    - cohort

--- a/schema/profiles/caf-study-result-source.yaml
+++ b/schema/profiles/caf-study-result-source.yaml
@@ -38,7 +38,7 @@ $defs:
       locusAlleleCount:
         type: integer
         description: >-
-          The number of occurrences of all alleles at the locus in the cohort 
+          The number of occurrences of all alleles at the locus in the cohort
           (sometimes referred to as "allele number")
       focusAlleleFrequency:
         type: number

--- a/schema/profiles/def/CohortAlleleFrequencyStudyResult.rst
+++ b/schema/profiles/def/CohortAlleleFrequencyStudyResult.rst
@@ -83,12 +83,12 @@ Some CohortAlleleFrequencyStudyResult attributes are inherited from :ref:`gks.co
    *  - locusAlleleCount
       - integer
       - 1..1
-      - The number of occurrences of alleles at the locus in the cohort (count of all alleles at this locus, sometimes referred to as "allele number")
-   *  - alleleFrequency
+      - The number of occurrences of all alleles at the locus in the cohort  (sometimes referred to as "allele number")
+   *  - focusAlleleFrequency
       - number
-      - 1..1
+      - 0..1
       - The frequency of the focusAllele in the cohort.
-   *  - cohortStudyGroup
+   *  - cohort
       - `StudyGroup <../core-im/core.json#/$defs/StudyGroup>`_
       - 1..1
       - The cohort from which the frequency was derived.

--- a/schema/profiles/def/CohortAlleleFrequencyStudyResult.rst
+++ b/schema/profiles/def/CohortAlleleFrequencyStudyResult.rst
@@ -83,10 +83,10 @@ Some CohortAlleleFrequencyStudyResult attributes are inherited from :ref:`gks.co
    *  - locusAlleleCount
       - integer
       - 1..1
-      - The number of occurrences of all alleles at the locus in the cohort  (sometimes referred to as "allele number")
+      - The number of occurrences of all alleles at the locus in the cohort (sometimes referred to as "allele number")
    *  - focusAlleleFrequency
       - number
-      - 0..1
+      - 1..1
       - The frequency of the focusAllele in the cohort.
    *  - cohort
       - `StudyGroup <../core-im/core.json#/$defs/StudyGroup>`_

--- a/schema/profiles/json/CohortAlleleFrequencyStudyResult
+++ b/schema/profiles/json/CohortAlleleFrequencyStudyResult
@@ -124,7 +124,7 @@
       },
       "locusAlleleCount": {
          "type": "integer",
-         "description": "The number of occurrences of all alleles at the locus in the cohort  (sometimes referred to as \"allele number\")"
+         "description": "The number of occurrences of all alleles at the locus in the cohort (sometimes referred to as \"allele number\")"
       },
       "focusAlleleFrequency": {
          "type": "number",
@@ -144,10 +144,10 @@
       }
    },
    "required": [
-      "alleleFrequency",
       "cohort",
       "focusAllele",
       "focusAlleleCount",
+      "focusAlleleFrequency",
       "id",
       "locusAlleleCount",
       "type"

--- a/schema/profiles/json/CohortAlleleFrequencyStudyResult
+++ b/schema/profiles/json/CohortAlleleFrequencyStudyResult
@@ -113,7 +113,7 @@
             {
                "type": "string",
                "format": "uri-reference",
-               "description": "The Allele for which the frequency is being reported."
+               "description": "The Allele for which frequency results are reported."
             }
          ],
          "description": "The specific subject or experimental unit in a Study that data in the StudyResult object is about. e.g. a particular variant in a population allele frequency dataset like ExAC or gnomAD."
@@ -124,13 +124,13 @@
       },
       "locusAlleleCount": {
          "type": "integer",
-         "description": "The number of occurrences of alleles at the locus in the cohort (count of all alleles at this locus, sometimes referred to as \"allele number\")"
+         "description": "The number of occurrences of all alleles at the locus in the cohort  (sometimes referred to as \"allele number\")"
       },
-      "alleleFrequency": {
+      "focusAlleleFrequency": {
          "type": "number",
          "description": "The frequency of the focusAllele in the cohort."
       },
-      "cohortStudyGroup": {
+      "cohort": {
          "$ref": "/ga4gh/schema/gks-core-im/1.x/core-im/json/StudyGroup",
          "description": "The cohort from which the frequency was derived."
       },
@@ -145,7 +145,7 @@
    },
    "required": [
       "alleleFrequency",
-      "cohortStudyGroup",
+      "cohort",
       "focusAllele",
       "focusAlleleCount",
       "id",

--- a/tests/fixtures/cohort-allele-freq-test.yaml
+++ b/tests/fixtures/cohort-allele-freq-test.yaml
@@ -8,8 +8,7 @@
 # 2. class 'type' value was modified from 'CohortAlleleFrequency' to 'CohortAlleleFrequencyStudyResult'
 # 3. 'derivedFrom' was renamed to 'sourceDataSet'
 # 4. 'sourceDataset' (frmrly derivedFrom) was modified to be an array of 1 item instead of a single object
-# 5. 'cohort' was renamed to 'cohortStudyGroup'
-# 6. 'subcohortFrequency' was renamed to 'subCohortFrequency'
+# 5. 'subcohortFrequency' was renamed to 'subCohortFrequency'
 
 
 id: gnomad4:1-10120-T-G
@@ -24,7 +23,7 @@ focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
 focusAlleleCount: 0
 locusAlleleCount: 34086
 alleleFrequency: 0
-cohortStudyGroup:
+cohort:
   id: ALL
   label: Overall
   type: StudyGroup
@@ -41,7 +40,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 468
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: remaining
     label: Remaining individuals Ancestry Group
     type: StudyGroup
@@ -60,7 +59,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 2282
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: amr
     label: Admixed American Ancestry Group
     type: StudyGroup
@@ -79,7 +78,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 1112
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: fin
     label: Finnish Ancestry Group
     type: StudyGroup
@@ -98,7 +97,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 190
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: ami
     label: Amish Ancestry Group
     type: StudyGroup
@@ -117,7 +116,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 872
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: eas
     label: East Asian Ancestry Group
     type: StudyGroup
@@ -136,7 +135,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 32
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: mid
     label: Middle Eastern Ancestry Group
     type: StudyGroup
@@ -155,7 +154,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 716
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: sas
     label: South Asian Ancestry Group
     type: StudyGroup
@@ -174,7 +173,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 1076
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: asj
     label: Ashkenazi Jewish Ancestry Group
     type: StudyGroup
@@ -193,7 +192,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 8666
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: afr
     label: African/African-American Ancestry Group
     type: StudyGroup
@@ -212,7 +211,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 18672
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: nfe
     label: Non-Finnish European Ancestry Group
     type: StudyGroup
@@ -231,7 +230,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 18952
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: XX
     label: XX
     type: StudyGroup
@@ -250,7 +249,7 @@ subCohortFrequency:
   focusAlleleCount: 0
   locusAlleleCount: 15134
   alleleFrequency: 0
-  cohortStudyGroup:
+  cohort:
     id: XY
     label: XY
     type: StudyGroup

--- a/tests/fixtures/cohort-allele-freq-test.yaml
+++ b/tests/fixtures/cohort-allele-freq-test.yaml
@@ -22,7 +22,7 @@ sourceDataSet:
 focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
 focusAlleleCount: 0
 locusAlleleCount: 34086
-alleleFrequency: 0
+focusAlleleFrequency: 0
 cohort:
   id: ALL
   label: Overall
@@ -39,7 +39,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 468
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: remaining
     label: Remaining individuals Ancestry Group
@@ -58,7 +58,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 2282
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: amr
     label: Admixed American Ancestry Group
@@ -77,7 +77,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 1112
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: fin
     label: Finnish Ancestry Group
@@ -96,7 +96,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 190
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: ami
     label: Amish Ancestry Group
@@ -115,7 +115,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 872
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: eas
     label: East Asian Ancestry Group
@@ -134,7 +134,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 32
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: mid
     label: Middle Eastern Ancestry Group
@@ -153,7 +153,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 716
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: sas
     label: South Asian Ancestry Group
@@ -172,7 +172,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 1076
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: asj
     label: Ashkenazi Jewish Ancestry Group
@@ -191,7 +191,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 8666
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: afr
     label: African/African-American Ancestry Group
@@ -210,7 +210,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 18672
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: nfe
     label: Non-Finnish European Ancestry Group
@@ -229,7 +229,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 18952
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: XX
     label: XX
@@ -248,7 +248,7 @@ subCohortFrequency:
   focusAllele: ga4gh:VA.XTZZHRCS2lIZuST7_LnLSHwro5uYYtVF
   focusAlleleCount: 0
   locusAlleleCount: 15134
-  alleleFrequency: 0
+  focusAlleleFrequency: 0
   cohort:
     id: XY
     label: XY


### PR DESCRIPTION
- Minor changes to schema title, and a couple attribute descriptions

- Changed `cohortStudyGroup` attribute name to just `cohort` (per outcome of previous conversations about this)