### PR TITLE
Initial functional assay data model

### DIFF
--- a/examples/mavedb/pten-variant-example.json
+++ b/examples/mavedb/pten-variant-example.json
@@ -1,0 +1,140 @@
+{
+    "urn:mavedb:00000013-a-1#4288": {
+        "AssayVariantEffectMeasurementStudyResult": {
+            "type": "AssayVariantEffectMeasurementStudyResult",
+            "focusVariant": {
+                "id": "ga4gh:VA.t0rDoiIessOWmP0SF0plhXtOwi8TRaZz",
+                "type": "VariationDescriptor",
+                "variation": {
+                    "id": "ga4gh:VA.t0rDoiIessOWmP0SF0plhXtOwi8TRaZz",
+                    "type": "Allele",
+                    "location": {
+                        "id": null,
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi",
+                        "interval": {
+                            "type": "SequenceInterval",
+                            "start": {
+                                "type": "Number",
+                                "value": 10
+                            },
+                            "end": {
+                                "type": "Number",
+                                "value": 11
+                            }
+                        }
+                    },
+                    "state": {
+                        "type": "LiteralSequenceExpression",
+                        "sequence": "T"
+                    }
+                },
+                "expressions": [
+                    {
+                        "type": "Expression",
+                        "syntax": "hgvs.p",
+                        "value": "NP_000305.3:p.Arg11Thr",
+                        "syntax_version": null
+                    }
+                ],
+                "vrs_ref_allele_seq": "R"
+            },
+            "score": 1.29395467005388,
+            "isReportedIn": "urn:mavedb:00000013-a-1"    
+        },
+        "AssayVariantEffectFunctionalClassificationStatement": {
+            "type": "AssayVariantEffectFunctionalClassificationStatement",
+            "subjectVariant": {
+                "id": "ga4gh:VA.t0rDoiIessOWmP0SF0plhXtOwi8TRaZz",
+                "type": "VariationDescriptor",
+                "variation": {
+                    "id": "ga4gh:VA.t0rDoiIessOWmP0SF0plhXtOwi8TRaZz",
+                    "type": "Allele",
+                    "location": {
+                        "id": null,
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi",
+                        "interval": {
+                            "type": "SequenceInterval",
+                            "start": {
+                                "type": "Number",
+                                "value": 10
+                            },
+                            "end": {
+                                "type": "Number",
+                                "value": 11
+                            }
+                        }
+                    },
+                    "state": {
+                        "type": "LiteralSequenceExpression",
+                        "sequence": "T"
+                    }
+                },
+                "expressions": [
+                    {
+                        "type": "Expression",
+                        "syntax": "hgvs.p",
+                        "value": "NP_000305.3:p.Arg11Thr",
+                        "syntax_version": null
+                    }
+                ],
+                "vrs_ref_allele_seq": "R"
+            },
+            "predicate": "hasAssayVariantEffectFor",
+            "objectAssay": "https://github.com/ave-dcd/mave_vocabulary/blob/main/examples/Matreyek_2018.yml",
+            "subjectClassification": "normal",
+            "specifiedBy": {
+                "type": "Method",
+                "isReportedIn": "https://pubmed.ncbi.nlm.nih.gov/29785012/"
+            }
+        },
+        "AssayVariantEffectClinicalClassificationStatement": {
+            "type": "AssayVariantEffectClinicalClassificationStatement",
+            "subjectVariant": {
+                "id": "ga4gh:VA.t0rDoiIessOWmP0SF0plhXtOwi8TRaZz",
+                "type": "VariationDescriptor",
+                "variation": {
+                    "id": "ga4gh:VA.t0rDoiIessOWmP0SF0plhXtOwi8TRaZz",
+                    "type": "Allele",
+                    "location": {
+                        "id": null,
+                        "type": "SequenceLocation",
+                        "sequence_id": "ga4gh:SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi",
+                        "interval": {
+                            "type": "SequenceInterval",
+                            "start": {
+                                "type": "Number",
+                                "value": 10
+                            },
+                            "end": {
+                                "type": "Number",
+                                "value": 11
+                            }
+                        }
+                    },
+                    "state": {
+                        "type": "LiteralSequenceExpression",
+                        "sequence": "T"
+                    }
+                },
+                "expressions": [
+                    {
+                        "type": "Expression",
+                        "syntax": "hgvs.p",
+                        "value": "NP_000305.3:p.Arg11Thr",
+                        "syntax_version": null
+                    }
+                ],
+                "vrs_ref_allele_seq": "R"
+            },
+            "predicate": "hasAssayVariantEffectFor",
+            "objectAssay": "https://github.com/ave-dcd/mave_vocabulary/blob/main/examples/Matreyek_2018.yml",
+            "subjectClassification": "BS3_Supporting",
+            "specifiedBy": {
+                "type": "Method",
+                "isReportedIn": "https://pubmed.ncbi.nlm.nih.gov/34793697/"
+            }
+        }
+    }
+}

--- a/examples/mavedb/pten-variant-example.json
+++ b/examples/mavedb/pten-variant-example.json
@@ -40,7 +40,17 @@
                 "vrs_ref_allele_seq": "R"
             },
             "score": 1.29395467005388,
-            "isReportedIn": "urn:mavedb:00000013-a-1"    
+            "specifiedBy": {
+                "type": "Method",
+                "subtype": "Experimental Protocol",
+                "reportedIn": "https://pubmed.ncbi.nlm.nih.gov/29785012/",
+                },
+            "sourceDataSet": {
+                "type": "DataSet",
+                "subtype": "variant effect data set",
+                "license": "CC0",
+                "reportedIn": "https://mavedb.org/score-sets/urn:mavedb:00000013-a-1"
+            }
         },
         "AssayVariantEffectFunctionalClassificationStatement": {
             "type": "AssayVariantEffectFunctionalClassificationStatement",
@@ -86,7 +96,8 @@
             "subjectClassification": "normal",
             "specifiedBy": {
                 "type": "Method",
-                "isReportedIn": "https://pubmed.ncbi.nlm.nih.gov/29785012/"
+                "subtype": "Variant Interpretation Guideline",
+                "reportedIn": "https://pubmed.ncbi.nlm.nih.gov/29785012/"
             }
         },
         "AssayVariantEffectClinicalClassificationStatement": {
@@ -133,7 +144,8 @@
             "subjectClassification": "BS3_Supporting",
             "specifiedBy": {
                 "type": "Method",
-                "isReportedIn": "https://pubmed.ncbi.nlm.nih.gov/34793697/"
+                "subtype": "Variant Interpretation Guideline",
+                "reportedIn": "https://pubmed.ncbi.nlm.nih.gov/34793697/"
             }
         }
     }

--- a/schema/profiles/assay-var-effect-source.yaml
+++ b/schema/profiles/assay-var-effect-source.yaml
@@ -16,7 +16,7 @@ $defs:
     maturity: draft
     type: object
     description: >-
-      TODO @alanrubin will fill out a description
+      A statement that assigns a functional classification to a variant effect from a functional assay.
     properties:
       type:
         extends: type
@@ -69,7 +69,7 @@ $defs:
     maturity: draft
     type: object
     description: >-
-      A StudyResult that reports measures related to the frequency of an Allele in a cohort
+      A StudyResult that reports a variant effect score from a functional assay.
     properties:
       type:
         extends: type

--- a/schema/profiles/assay-var-effect-source.yaml
+++ b/schema/profiles/assay-var-effect-source.yaml
@@ -132,6 +132,7 @@ $defs:
         const: "AssayVariantEffectMeasurementStudyResult"
         default: "AssayVariantEffectMeasurementStudyResult"
         description: MUST be "AssayVariantEffectMeasurementStudyResult".
+      # @Larry why is this focusVariant instead of subjectVariant?
       focusVariant:
         extends: focus
         oneOf:

--- a/schema/profiles/assay-var-effect-source.yaml
+++ b/schema/profiles/assay-var-effect-source.yaml
@@ -126,7 +126,6 @@ $defs:
     type: object
     description: >-
       A StudyResult that reports a variant effect score from a functional assay.
-      A StudyResult that reports a variant effect score from a functional assay.
     properties:
       type:
         extends: type
@@ -144,10 +143,11 @@ $defs:
       score:
         type: number
         description: The score of the variant effect in the assay.
-      reportedIn:
-        description:  The assay that was used to measure the variant effect with all the various properties
-        extends: reportedIn
-        # minItems: 1
-        # url: document url
-
-
+      specifiedBy:
+        description: >-
+          The assay that was used to measure the variant effect with all the various properties
+        extends: specifiedBy
+      sourceDataSet:
+        description: >-
+          The full data set that this measurement is a part of
+        extends: sourceDataSet

--- a/schema/profiles/assay-var-effect-source.yaml
+++ b/schema/profiles/assay-var-effect-source.yaml
@@ -73,12 +73,9 @@ $defs:
     properties:
       type:
         extends: type
-        const: "AssayVariantEffectFunctionalClassificationStatement"
-        default: "AssayVariantEffectFunctionalClassificationStatement"
-        description: MUST be "AssayVariantEffectFunctionalClassificationStatement".
-        const: "AssayVariantEffectFunctionalClassificationStatement"
-        default: "AssayVariantEffectFunctionalClassificationStatement"
-        description: MUST be "AssayVariantEffectFunctionalClassificationStatement".
+        const: "AssayVariantEffectClinicalClassificationStatement"
+        default: "AssayVariantEffectClinicalClassificationStatement"
+        description: MUST be "AssayVariantEffectClinicalClassificationStatement".
       subjectVariant:
         extends: subject
         oneOf:
@@ -101,7 +98,7 @@ $defs:
           The assay that is evaluated for the variant effect. (e.g growth in
           haploid cell culture protein stability in fluorescence assay)
       subjectClassification:
-        extends: subjectClassification
+        extends: classification
         description: >-
           The clinical strength of evidence of the variant effect in the assay.
         enum:

--- a/schema/profiles/assay-var-effect-source.yaml
+++ b/schema/profiles/assay-var-effect-source.yaml
@@ -11,7 +11,7 @@ imports:
 
 $defs:
   # mavedb work in progress (super early draft)
-  AssayVariantEffectClassificationStatement:
+  AssayVariantEffectFunctionalClassificationStatement:
     inherits: gks.core-im:Statement
     maturity: draft
     type: object
@@ -20,9 +20,9 @@ $defs:
     properties:
       type:
         extends: type
-        const: "AssayVariantEffectClassificationStatement"
-        default: "AssayVariantEffectClassificationStatement"
-        description: MUST be "AssayVariantEffectClassificationStatement".
+        const: "AssayVariantEffectFunctionalClassificationStatement"
+        default: "AssayVariantEffectFunctionalClassificationStatement"
+        description: MUST be "AssayVariantEffectFunctionalClassificationStatement".
       subjectVariant:
         extends: subject
         oneOf:
@@ -47,7 +47,7 @@ $defs:
       classification:
         extends: classification
         description: >-
-          The classification of the variant effect in the assay.
+          The functional classification of the variant effect in the assay.
         enum:
           - normal
           - indeterminate
@@ -56,7 +56,63 @@ $defs:
       specifiedBy:
         extends: specifiedBy
         description: >-
-          The method that specifies the classification of the variant effect in the assay.
+          The method that specifies the functional classification of the variant effect in the assay.
+        # will will likely need to enhance this a bit due to the complexity of the methods used
+    required:
+      - subjectVariant
+      - predicate
+      - objectAssay
+      - subjectClassification
+
+  AssayVariantEffectClinicalClassificationStatement:
+    inherits: gks.core-im:Statement
+    maturity: draft
+    type: object
+    description: >-
+      A statement that assigns a clinical strength of evidence to a variant effect from a functional assay.
+    properties:
+      type:
+        extends: type
+        const: "AssayVariantEffectFunctionalClassificationStatement"
+        default: "AssayVariantEffectFunctionalClassificationStatement"
+        description: MUST be "AssayVariantEffectFunctionalClassificationStatement".
+      subjectVariant:
+        extends: subject
+        oneOf:
+          - $ref: "/ga4gh/schema/vrs/2.x/json/MolecularVariation"
+          - $ref: "/ga4gh/schema/cat-vrs/1.x/json/CategoricalVariation"
+          - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/IRI"
+        description: A protein or genomic contextual or canonical molecular variant.
+      predicate:
+        extends: predicate
+        enum:
+          - hasAssayVariantEffectFor
+      objectAssay:
+        # TODO we may need to model this more specifically as a DomainEntity subtype
+        extends: object
+        oneOf:
+          - type: string
+          - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/IRI"
+          - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/Coding"
+        description: >-
+          The assay that is evaluated for the variant effect. (e.g growth in
+          haploid cell culture protein stability in fluorescence assay)
+      subjectClassification:
+        extends: subjectClassification
+        description: >-
+          The clinical strength of evidence of the variant effect in the assay.
+        enum:
+          - PS3_Strong
+          - PS3_Moderate
+          - PS3_Supporting
+          - BS3_Strong
+          - BS3_Moderate
+          - BS3_Supporting
+      # method for classification contains info about thresholds for how to classify
+      specifiedBy:
+        extends: specifiedBy
+        description: >-
+          The method that specifies the clinical strength of evidence of the variant effect in the assay.
         # will will likely need to enhance this a bit due to the complexity of the methods used
     required:
       - subjectVariant

--- a/schema/profiles/assay-var-effect-source.yaml
+++ b/schema/profiles/assay-var-effect-source.yaml
@@ -132,6 +132,7 @@ $defs:
         const: "AssayVariantEffectMeasurementStudyResult"
         default: "AssayVariantEffectMeasurementStudyResult"
         description: MUST be "AssayVariantEffectMeasurementStudyResult".
+      # @Larry why is this focusVariant instead of subjectVariant?
       focusVariant:
         extends: focus
         oneOf:
@@ -143,6 +144,7 @@ $defs:
       score:
         type: number
         description: The score of the variant effect in the assay.     
+      # @Larry does this need objectAssay also?
       isReportedIn:
         description:  The assay that was used to measure the variant effect with all the various properties
         extends: isReportedIn

--- a/schema/profiles/assay-var-effect-source.yaml
+++ b/schema/profiles/assay-var-effect-source.yaml
@@ -11,7 +11,7 @@ imports:
 
 $defs:
   # mavedb work in progress (super early draft)
-  AssayVariantEffectClassificationStatement:
+  AssayVariantEffectFunctionalClassificationStatement:
     inherits: gks.core-im:Statement
     maturity: draft
     type: object
@@ -20,9 +20,9 @@ $defs:
     properties:
       type:
         extends: type
-        const: "AssayVariantEffectClassificationStatement"
-        default: "AssayVariantEffectClassificationStatement"
-        description: MUST be "AssayVariantEffectClassificationStatement".
+        const: "AssayVariantEffectFunctionalClassificationStatement"
+        default: "AssayVariantEffectFunctionalClassificationStatement"
+        description: MUST be "AssayVariantEffectFunctionalClassificationStatement".
       subjectVariant:
         extends: subject
         oneOf:
@@ -47,7 +47,7 @@ $defs:
       subjectClassification:
         extends: subjectClassification
         description: >-
-          The classification of the variant effect in the assay.
+          The functional classification of the variant effect in the assay.
         enum:
           - normal 
           - indeterminate
@@ -56,7 +56,63 @@ $defs:
       specifiedBy:
         extends: specifiedBy
         description: >-
-          The method that specifies the classification of the variant effect in the assay.
+          The method that specifies the functional classification of the variant effect in the assay.
+        # will will likely need to enhance this a bit due to the complexity of the methods used
+    required:
+      - subjectVariant
+      - predicate
+      - objectAssay
+      - subjectClassification
+
+  AssayVariantEffectClinicalClassificationStatement:
+    inherits: gks.core-im:Statement
+    maturity: draft
+    type: object
+    description: >-
+      A statement that assigns a clinical strength of evidence to a variant effect from a functional assay.
+    properties:
+      type:
+        extends: type
+        const: "AssayVariantEffectFunctionalClassificationStatement"
+        default: "AssayVariantEffectFunctionalClassificationStatement"
+        description: MUST be "AssayVariantEffectFunctionalClassificationStatement".
+      subjectVariant:
+        extends: subject
+        oneOf:
+          - $ref: "/ga4gh/schema/vrs/2.x/json/MolecularVariation"
+          - $ref: "/ga4gh/schema/cat-vrs/1.x/json/CategoricalVariation"
+          - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/IRI"
+        description: A protein or genomic contextual or canonical molecular variant.
+      predicate:
+        extends: predicate
+        enum:
+          - hasAssayVariantEffectFor
+      objectAssay:
+        # TODO we may need to model this more specifically as a DomainEntity subtype
+        extends: object
+        oneOf:
+          - type: string
+          - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/IRI"
+          - $ref: "/ga4gh/schema/gks-common/1.x/data-types/json/Coding"
+        description: >-
+          The assay that is evaluated for the variant effect. (e.g growth in
+          haploid cell culture protein stability in fluorescence assay)
+      subjectClassification:
+        extends: subjectClassification
+        description: >-
+          The clinical strength of evidence of the variant effect in the assay.
+        enum:
+          - PS3_Strong
+          - PS3_Moderate
+          - PS3_Supporting
+          - BS3_Strong
+          - BS3_Moderate
+          - BS3_Supporting
+      # method for classification contains info about thresholds for how to classify
+      specifiedBy:
+        extends: specifiedBy
+        description: >-
+          The method that specifies the clinical strength of evidence of the variant effect in the assay.
         # will will likely need to enhance this a bit due to the complexity of the methods used
     required:
       - subjectVariant


### PR DESCRIPTION
Following discussions with @larrybabb and @ahwagner, this PR adds three data models for representing functional assay data in VA-Spec:
* `AssayVariantEffectMeasurementStudyResult`
* `AssayVariantEffectFunctionalClassificationStatement`
* `AssayVariantEffectClinicalClassificationStatement`

The goal of this structure is to represent both the "raw" assay score and also the two types of statements commonly made when using the data: whether a variant is functional or not and what clinical strength of evidence can be applied.

The PR also includes an example variant from a real MaveDB dataset.

I'm not sure what happened with the Cat-VRS submodule stuff during the rebase, but hopefully it can be ignored/easily resolved.