### PR TITLE
docs: fix some typos/grammatical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VA-spec
 
-**Official Documentaation:** https://va-ga4gh.readthedocs.io/en/latest
+**Official Documentation:** https://va-ga4gh.readthedocs.io/en/latest
 
  **VA-Spec 1.0.0 Trial Use Review November 2024 - join in [here](https://github.com/ga4gh/va-spec/discussions/234)!**
 
@@ -8,19 +8,19 @@
 
 ### Overview 
 
-**Variant Annotations** are structured data object that holds a central piece of knowledge (a '**statement**') about a molecular variation (aka 'variant'), along with metadata supporting its interpretation and use. For example, a given annotation may assert knowledge about a variant's pathogenicity, impact on gene function, population frequency, molecular consequence, or effect on therapeutic response to treatment - and provide evidence and provenance information supporting this statement.
+**Variant Annotations** are structured data objects that hold a central piece of knowledge (a '**statement**') about a molecular variation (aka 'variant'), along with metadata supporting its interpretation and use. For example, a given annotation may assert knowledge about a variant's pathogenicity, impact on gene function, population frequency, molecular consequence, or effect on therapeutic response to treatment - and provide evidence and provenance information supporting this statement.
 
-The GA4GH VA-Specification (VA-Spec) defines a **set of information models** to represent different kinds of statements made about genetic variants- each built as **"profiles"** that extend a foundational **core information model**. It provides machine-readable **json-schema specifications** of these models, to support sharing and validation of data through APIs and other exchange mechanisms. It also provides a **modeling framework** through which implementers can build profiles for new statement types, or refine and extend existing statement profiles to support novel use cases. 
-This framework has allowed for **implementation-driven development** that reduces bottlenecks imposed by centralized approaches, leverages the collective expertise and perspective of diverse applications, and delivers schema that have bene proven out in working data systems.
+The GA4GH VA-Specification (VA-Spec) defines a **set of information models** to represent different kinds of statements made about genetic variants - each built as **"profiles"** that extend a foundational **core information model**. It provides machine-readable **json-schema specifications** of these models, to support sharing and validation of data through APIs and other exchange mechanisms. It also provides a **modeling framework** through which implementers can build profiles for new statement types, or refine and extend existing statement profiles to support novel use cases. 
+This framework has allowed for **implementation-driven development** that reduces bottlenecks imposed by centralized approaches, leverages the collective expertise and perspective of diverse applications, and delivers schema that have been proven out in working data systems.
 
-The VA-Spec core information model and profiling approach is based on the [Scientific Evidence and Provenance Information Ontology (SEPIO) Model and Framework](https://sepio-framework.github.io/sepio-linkml/). SEPIO is already being applied by several VA Driver Projects, and its contributors are also members of various GA4GH workstreams. These existing integrations will facilitate the coordinated evolution of the VA ad SEPIO standards.
+The VA-Spec core information model and profiling approach is based on the [Scientific Evidence and Provenance Information Ontology (SEPIO) Model and Framework](https://sepio-framework.github.io/sepio-linkml/). SEPIO is already being applied by several VA Driver Projects, and its contributors are also members of various GA4GH workstreams. These existing integrations will facilitate the coordinated evolution of the VA and SEPIO standards.
 
 The VA-Spec is being authored by a partnership among national resource providers and major public initiatives, working under the governance of the GA4GH. It has been informed and tested in diverse, established, and actively developed Driver Projects, including **ClinGen**, **VICC**, **Genomics England**, the **Monarch Initiative**, **BRCA Exchange**, and **MAVEdb**. In these projects, it is/will be applied to support different types of tools and information systems, including variant **curation tools** and **interpretation platforms** (e.g. ClinGen, CIViC), variant **annotation services** (e.g. Genomics England/CellBase), **knowledge aggregators** (BRCA Exchange, Monarch Initiative), and experimental variant **analysis pipelines** (MAVEdb).
 
 
 ### VA-Spec Components:
 1. **A Generic Core Information Model (IM)**. A foundational, domain-agnostic conceptual model that includes SEPIO elements pertinent to VA use cases. *Provides a base on which VA-specific Statement Profiles are built for the GA4GH Community*. ([`LINK`](https://va-ga4gh.readthedocs.io/en/latest/core-information-model/index.html))
-2. **Standard VA Profiles**: A set of standard models that extend the Core IM to represent specific Statement types, formalized as json-schema specifications. *Provides GA4GH community with recommended standards for out-of-the-box interoperability, and example of how to apply the modeling framework to create new Profiles.* ([`LINK`](https://va-ga4gh.readthedocs.io/en/latest/standard-profiles/index.html))
+2. **Standard VA Profiles**: A set of standard models that extend the Core IM to represent specific Statement types, formalized as json-schema specifications. *Provides the GA4GH community with recommended standards for out-of-the-box interoperability, and examples of how to apply the modeling framework to create new Profiles.* ([`LINK`](https://va-ga4gh.readthedocs.io/en/latest/standard-profiles/index.html))
 3. **A Profiling Methodology**:  Implementation support and tooling to facilitate extension and de novo development of Profiles, and mechanisms for feedback to evolve the core spec. *Allows community-driven development and testing of new Profiles for specific annotation types and use cases*. (`IN PROGRESS`) 
 4. **Reference Implementation(s)**. A library of software and services that demonstrate the creation, validation, and exchange of compliant data using GA4GH Profiles. *Provides a working example of code that can be adopted and/or extended by adopters.* (`IN PROGRESS`) 
 


### PR DESCRIPTION
side question:

> SEPIO is already being applied by several VA Driver Projects, and its contributors are also members of various GA4GH workstreams

should this be "GA4GH Driver Projects"?