### PR TITLE
Updated variant example to NP_000305.3:p.Ile67Lys and validated tests

### DIFF
--- a/tests/fixtures/EVFI-proposition.yaml
+++ b/tests/fixtures/EVFI-proposition.yaml
@@ -11,15 +11,15 @@ subjectVariant:
           sequenceReference:
             refgetAccession: SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi
             type: SequenceReference
-          start: 10
-          end: 11
-          sequence: R
+          start: 66
+          end: 67
+          sequence: I
         state:
           type: LiteralSequenceExpression
-          sequence: T
+          sequence: K
         expressions:
           - syntax: hgvs.p
-            value: NP_000305.3:p.Arg11Thr
+            value: NP_000305.3:p.Ile67Lys
       relations:
         - primaryCode: translates_from
 predicate: impactsFunctionOf

--- a/tests/fixtures/Exp-Var-Func-Impact-Statement-01.yaml
+++ b/tests/fixtures/Exp-Var-Func-Impact-Statement-01.yaml
@@ -13,15 +13,15 @@ proposition:
             sequenceReference:
               refgetAccession: SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi
               type: SequenceReference
-            start: 10
-            end: 11
-            sequence: R
+            start: 66
+            end: 67
+            sequence: I
           state:
             type: LiteralSequenceExpression
-            sequence: T
+            sequence: K
           expressions:
             - syntax: hgvs.p
-              value: NP_000305.3:p.Arg11Thr
+              value: NP_000305.3:p.Ile67Lys
         relations:
           - primaryCode: translates_from
   predicate: impactsFunctionOf

--- a/tests/fixtures/Exp-Var-Func-Impact-Study-Result-01.yaml
+++ b/tests/fixtures/Exp-Var-Func-Impact-Study-Result-01.yaml
@@ -7,15 +7,15 @@ focusVariant:
     sequenceReference:
       refgetAccession: SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi
       type: SequenceReference
-    start: 10
-    end: 11
-    sequence: R
+    start: 66
+    end: 67
+    sequence: I
   state:
     type: LiteralSequenceExpression
-    sequence: T
+    sequence: K
   expressions:
     - syntax: hgvs.p
-      value: NP_000305.3:p.Arg11Thr
+      value: NP_000305.3:p.Ile67Lys
 functionalImpactScore: 1.29395467005388
 specifiedBy:
   type: Method

--- a/tests/fixtures/Var-Onco-Func-Impact-Evidence-Line-02.yaml
+++ b/tests/fixtures/Var-Onco-Func-Impact-Evidence-Line-02.yaml
@@ -14,15 +14,15 @@ targetProposition:
             sequenceReference:
               refgetAccession: SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi
               type: SequenceReference
-            start: 10
-            end: 11
-            sequence: R
+            start: 66
+            end: 67
+            sequence: I
           state:
             type: LiteralSequenceExpression
-            sequence: T
+            sequence: K
           expressions:
             - syntax: hgvs.p
-              value: NP_000305.3:p.Arg11Thr
+              value: NP_000305.3:p.Ile67Lys
         relations:
           - primaryCode: translates_from
   predicate: isOncogenicFor

--- a/tests/fixtures/Var-Path-Func-Impact-Evidence-Line-01.yaml
+++ b/tests/fixtures/Var-Path-Func-Impact-Evidence-Line-01.yaml
@@ -14,15 +14,15 @@ targetProposition:
             sequenceReference:
               refgetAccession: SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi
               type: SequenceReference
-            start: 10
-            end: 11
-            sequence: R
+            start: 66
+            end: 67
+            sequence: I
           state:
             type: LiteralSequenceExpression
-            sequence: T
+            sequence: K
           expressions:
             - syntax: hgvs.p
-              value: NP_000305.3:p.Arg11Thr
+              value: NP_000305.3:p.Ile67Lys
         relations:
           - primaryCode: translates_from
   predicate: isCausalFor

--- a/tests/fixtures/var-diagnostic-proposition.yaml
+++ b/tests/fixtures/var-diagnostic-proposition.yaml
@@ -14,15 +14,15 @@ subjectVariant:
           sequenceReference:
             refgetAccession: SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi
             type: SequenceReference
-          start: 10
-          end: 11
-          sequence: R
+          start: 66
+          end: 67
+          sequence: I
         state:
           type: LiteralSequenceExpression
-          sequence: T
+          sequence: K
         expressions:
           - syntax: hgvs.p
-            value: NP_000305.3:p.Arg11Thr
+            value: NP_000305.3:p.Ile67Lys
       relations:
         - primaryCode: translates_from
 predicate: isDiagnosticInclusionCriterionFor

--- a/tests/fixtures/var-onco-proposition.yaml
+++ b/tests/fixtures/var-onco-proposition.yaml
@@ -13,15 +13,15 @@ subjectVariant:
           sequenceReference:
             refgetAccession: SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi
             type: SequenceReference
-          start: 10
-          end: 11
-          sequence: R
+          start: 66
+          end: 67
+          sequence: I
         state:
           type: LiteralSequenceExpression
-          sequence: T
+          sequence: K
         expressions:
           - syntax: hgvs.p
-            value: NP_000305.3:p.Arg11Thr
+            value: NP_000305.3:p.Ile67Lys
       relations:
         - primaryCode: translates_from
 predicate: isOncogenicFor

--- a/tests/fixtures/var-prognostic-proposition.yaml
+++ b/tests/fixtures/var-prognostic-proposition.yaml
@@ -14,15 +14,15 @@ subjectVariant:
           sequenceReference:
             refgetAccession: SQ.w7LxW0PSaVPNsPFvOL24weFjHcfaHyOi
             type: SequenceReference
-          start: 10
-          end: 11
-          sequence: R
+          start: 66
+          end: 67
+          sequence: I
         state:
           type: LiteralSequenceExpression
-          sequence: T
+          sequence: K
         expressions:
           - syntax: hgvs.p
-            value: NP_000305.3:p.Arg11Thr
+            value: NP_000305.3:p.Ile67Lys
       relations:
         - primaryCode: translates_from
 predicate: associatedWithBetterOutcomeFor


### PR DESCRIPTION
the 'vrs:Allele' schema is missing or not properly loaded,the tests related to 'vrs:Allele' were skipped due to this issue.