### PR TITLE
Fix 1.0.0 snapshot.2025 02.1 references

### DIFF
--- a/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
@@ -19,7 +19,7 @@ $defs:
     - $ref: "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Statement"
     - properties:
         proposition:
-          $ref: "/ga4gh/schema/va-spec/1.x/base/json/VariantDiagnosticProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-snapshot.2025-02.1/base/json/VariantDiagnosticProposition"
           description: >-
             A proposition about a diagnostic association between a variant and condition, for which the study provides
             evidence. The validity of this proposition, and the level of confidence/evidence supporting it,

--- a/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
@@ -18,7 +18,7 @@ $defs:
     - $ref: "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Statement"
     - properties:
         proposition:
-          $ref: "/ga4gh/schema/va-spec/1.x/base/json/VariantPrognosticProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-snapshot.2025-02.1/base/json/VariantPrognosticProposition"
           description: >-
             A proposition about a prognostic association between a variant and condition, for which the study provides
             evidence. The validity of this proposition, and the level of confidence/evidence supporting it,

--- a/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
@@ -18,7 +18,7 @@ $defs:
     - $ref: "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Statement"
     - properties:
         proposition:
-          $ref: "/ga4gh/schema/va-spec/1.x/base/json/VariantTherapeuticResponseProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-snapshot.2025-02.1/base/json/VariantTherapeuticResponseProposition"
           description: >-
             A proposition about the therapeutic response associated with a variant, for which the study provides
             evidence. The validity of this proposition, and the level of confidence/evidence supporting it,

--- a/schema/va-spec/acmg-2015/pathogenicity-functional-impact-evidence-line-profile-source.yaml
+++ b/schema/va-spec/acmg-2015/pathogenicity-functional-impact-evidence-line-profile-source.yaml
@@ -20,7 +20,7 @@ $defs:
           description: >-
             A Variant Pathogenicity Proposition against which functional impact information was assessed,
             in determining the strength and direction of support this information provides as evidence.
-          $ref: "/ga4gh/schema/va-spec/1.x/base/json/VariantPathogenicityProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-snapshot.2025-02.1/base/json/VariantPathogenicityProposition"
         strengthOfEvidenceProvided:
           description: >-
             The strength of support that an Evidence Line is determined to provide for or against the

--- a/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
+++ b/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
@@ -20,7 +20,7 @@ $defs:
           description: >-
             A Variant Oncoogenicity Proposition against which functional impact information was assessed,
             in determining the strength and direction of support this information provides as evidence.
-          $ref: "/ga4gh/schema/va-spec/1.x/base/json/VariantOncogenicityProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-snapshot.2025-02.1/base/json/VariantOncogenicityProposition"
         strengthOfEvidenceProvided:
           description: >-
             The strength of support that an Evidence Line is determined to provide for or against the

--- a/schema/va-spec/ccv-2022/oncogenicity-study-statement-profile-source.yaml
+++ b/schema/va-spec/ccv-2022/oncogenicity-study-statement-profile-source.yaml
@@ -18,7 +18,7 @@ $defs:
     - $ref: "/ga4gh/schema/gks-core/1.0.0-snapshot.2025-02.2/json/Statement"
     - properties:
         proposition:
-          $ref: "/ga4gh/schema/va-spec/1.x/base/json/VariantOncogenicityProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-snapshot.2025-02.1/base/json/VariantOncogenicityProposition"
           description: >-
             A proposition about the oncogenicity of a varaint, for which the study provides evidence.
             The validity of this proposition, and the level of confidence/evidence supporting it,


### PR DESCRIPTION
It doesn't look like these were updated in the Nov 2024 ballot releases: https://github.com/ga4gh/va-spec/blob/1.0.0-ballot.2024-11.2/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml . 

Might be good in the future to add tests to make sure we're being consistent