### PR TITLE
Updating specification for Condition, TraitSet and Therapy Group based on #252 and #253

### DIFF
--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -19,10 +19,13 @@ $defs:
       At present, individual conditions are represented using a MappableConcept that captures a code or name for the 
       condition, along with optional mappings and metadata about the code system. Groups of conditions are represented
       using the ConditionSet class, which are collections of 2 or more conditions, each represented as a MappableConcept.
+      By convention, cases where no condition is given by the data provider SHOULD be specified using a MappableConcept with 
+      a conceptType = "Absent". Additionally, either the 'name' or 'primaryCoding' attribute of a MappableConcept must
+      be populated.  The name or code may simple reiterate the conceptType (e.g. 'condition absent'), or report a more specific
+      nature or reason for the absence of a condition (e.g. 'Data Missing in Source', 'Condition Unknown', 'All Mendelian Diseases').
     oneOf:
       - $refCurie: gks.core:MappableConcept
       - $ref: "#/$defs/ConditionSet"
-
   # ConditionSet data structure to provide support for co-occuring or substitute conditions.
   ConditionSet:
     type: object

--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -107,9 +107,8 @@ $defs:
         $comment: >-
           The membershipOperator ‘OR’ should be used only in the specific scenario where a study is done on a cohort of individuals
           that receive one of the therapies in the group - and the treatment response is determined based on an aggregate statistical
-          analysis across all members of this mixed cohort – because the study does not provide the statistical power to make a
-          conclusion about response to each therapy individually.  In such cases, it would be misleading to create separate statements
-          about each therapy on its own. 
+          analysis across all members of this mixed cohort. In such cases, the study does not provide the statistical power to make a
+          conclusion about response to each therapy individually.  
           Therapies in such groups are typically related in their treatment mechanism (e.g. members of the same drug class), and recipients
           are pooled to make a single cohort that is large enough support a statistically significant results about that class of treatments.
           Future iterations of the VA-Spec may support representation of these categorical groupings of therapies, but for now we capture the

--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -14,7 +14,7 @@ $defs:
   Condition:
     maturity: trial use
     description: >-
-      A single condition (disease, phenotype, or trait), or a set of conditions (CondiotonSet).
+      A single condition (disease, phenotype, or trait), or a set of conditions (ConditionSet).
     $comment: >-
       At present, individual conditions are represented using a MappableConcept that captures a code or name for the 
       condition, along with optional mappings and metadata about the code system. Groups of conditions are represented

--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -14,21 +14,26 @@ $defs:
   Condition:
     maturity: trial use
     description: >-
-      A set of traits (TraitSet) or a single trait (Disease, Phenotype, etc.) that represents
-      the object of a Variant Pathogenicity statement.
+      A single condition (disease, phenotype, or trait), or a set of conditions (CondiotonSet).
+    $comment: >-
+      At present, individual conditions are represented using a MappableConcept that captures a code or name for the 
+      condition, along with optional mappings and metadata about the code system. Groups of conditions are represented
+      using the ConditionSet class, which are collections of 2 or more conditions, each represented as a MappableConcept.
     oneOf:
       - $refCurie: gks.core:MappableConcept
-      - $ref: "#/$defs/TraitSet"
+      - $ref: "#/$defs/ConditionSet"
 
-  # TraitSet data structure to provide support for co-occuring traits (i.e. diseases, phenotypes, etc.)
-  TraitSet:
+  # ConditionSet data structure to provide support for co-occuring or substitute conditions.
+  ConditionSet:
     type: object
     maturity: trial use
     inherits: gks-core:Element
     description: >-
-      A set of conditions (diseases, phenotypes, traits) that are co-occurring.
+      A set of conditions (diseases, phenotypes, traits).
+      A set of two or more conditions that co-occur in the same patient/subject, or are manifest 
+      individually in a differnet subset of participants in a research study.
     properties:
-      traits:
+      conditions:
         type: array
         ordered: false
         items:
@@ -36,12 +41,37 @@ $defs:
         description: >-
           A list of conditions (diseases, phenotypes, traits) that are co-occurring.
         minItems: 2
-
+      membershipOperator:
+        description: >- 
+        The logical relationship between members of the set, that indicates how they manifest in patients/research subjects. 
+        The value 'AND' indicates that all conditions in the set co-occur together in a given patient or subject.
+        The value 'OR' indicates that only one condition in the set manifests in each participant interrogated in a given study.
+        type: string
+        enum:
+           - AND
+           - OR
+        $comment: >-
+          The membershipOperator ‘OR’ should be used only in the specific scenario where a study is done on a cohort of individuals
+          that manfiest only one of the conditions in the set. Conclusions about this condition are determined based on an aggregate
+          statistical analysis across all members of this mixed cohort – because the study does not provide the statistical power to
+          make a conclusion about each condition individually.  In such cases, it would be misleading to create separate statements
+          about each condition on its own. 
+          Conditions in such groups are typically related in their etiology or manifestation, and patients are pooled to make a single
+          cohort that is large enough support a statistically significant results about this grouping of related conditions.
+          Future iterations of the VA-Spec may support representation of these categorical sets of conditions, but for now we capture the
+          individual therapies used in the study in a Condition set.
+        required:
+          - conditions
+          - membershipOperator              
   # Therapeutic
   Therapeutic:
     maturity: trial use
     description: >-
-      A group of therapies (TherapyGroup) or a single therapy (drug, procedure, behavioral intervention, etc.).
+      An individual therapy (drug, procedure, behavioral intervention, etc.), or group of therapies (TherapyGroup).
+    $comment: >-
+      At present, individual therapies are represented using a MappableConcept that captures a code or name for the therapy, 
+      along with optional mappings and metadata about the code system. Groups of therapies are represented using the 
+      TherapyGroup class, which are collections of 2 or more therapies, each represented as a MappableConcept.
     oneOf:
       - $refCurie: gks.core:MappableConcept
       - $ref: "#/$defs/TherapyGroup"
@@ -52,17 +82,38 @@ $defs:
     maturity: trial use
     inherits: gks-core:Element
     description: >-
-      A group of therapies that are applied together to treat a condition.
+      A group of two or more therapies that are applied in combination to a single patient/subject, or applied
+      individually to a differnet subset of participants in a research study.
     properties:
-      groupType:
-        $refCurie: gks.core:MappableConcept
-        description: The type of the therapy group.
       therapies:
         type: array
         ordered: false
         items:
           $refCurie: gks.core:MappableConcept
         description: >-
-          A list of therapies that are applied together to treat a condition.
+          A list of therapies that are applied to treat a condition.
         minItems: 2
+      membershipOperator:
+        description: >- 
+        The logical relationship between members of the group, that indicates how they were applied in treating
+        participants in a study.  The value 'AND' indicates that all therapies in the group were applied in combination
+        to a given patient or subject. The value 'OR' indicates that each therapy was applied individually to a distinct
+        subset of participants in the cohort that was interrogated in a given study.
+        type: string
+        enum:
+           - AND
+           - OR
+        $comment: >-
+          The membershipOperator ‘OR’ should be used only in the specific scenario where a study is done on a cohort of individuals
+          that receive one of the therapies in the group - and the treatment response is determined based on an aggregate statistical
+          analysis across all members of this mixed cohort – because the study does not provide the statistical power to make a
+          conclusion about response to each therapy individually.  In such cases, it would be misleading to create separate statements
+          about each therapy on its own. 
+          Therapies in such groups are typically related in their treatment mechanism (e.g. members of the same drug class), and recipients
+          are pooled to make a single cohort that is large enough support a statistically significant results about that class of treatments.
+          Future iterations of the VA-Spec may support representation of these categorical groupings of therapies, but for now we capture the
+          individual therapies used in the study in a TherapyGroup.
+        required:
+          - therapies
+          - membershipOperator        
 

--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -61,8 +61,6 @@ $defs:
           about each condition on its own. 
           Conditions in such groups are typically related in their etiology or manifestation, and patients are pooled to make a single
           cohort that is large enough support a statistically significant results about this grouping of related conditions.
-          Future iterations of the VA-Spec may support representation of these categorical sets of conditions, but for now we capture the
-          individual therapies used in the study in a Condition set.
         required:
           - conditions
           - membershipOperator              


### PR DESCRIPTION
Addresses #252

@larrybabb Note that I am proposing to rename TraitSet --> ConditionSet - as everywhere else in the spec (including the description of elements in this class) we call these conditions, not traits.   The term TraitSet is specific to ClinVar - but is not used anywhere else in the community AFAIK. Calling them ConditionSets would add important internal consistency to our spec. 

Note that there may be references to "TraitSet' from other schema docs in the va-spec-  and I did not find or change this yet.  We can do this if/when we move to using 'ConditionSet'.

If you strongly disagree @larrybabb , it would be easy to update this PR to go back to 'TraitSet'.