### PR TITLE
Update oncogenicity-functional-impact-evidence-line-profile-source.yaml

### DIFF
--- a/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
+++ b/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
@@ -23,11 +23,12 @@ $defs:
           $ref: "/ga4gh/schema/va-spec/1.x/base/json/VariantOncogenicityProposition"
         strengthOfEvidenceProvided:
           description: >-
-            The strength of support that an Evidence Line is determined to provide for or against the
-            proposition or the oncogenicity of the assessed variant. Strength is evaluated relative to
-            the direction indicated by the directionOfEvidenceProvided attribute.
-            *Conditional requirement: if directionOfEvidenceProvided is either 'supports' or 'disputes',
-            then this attribute is required. If it is 'none', then this attribute is not allowed.
+            The strength of support that an Evidence Line is determined to provide for or against the proposed
+            pathogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by
+            the 'directionOfEvidenceProvided' attribute. The indicated enumeration constrains the nested 
+            MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength. 
+            Conditional requirement: if directionOfEvidenceProvided is either 'supports' or 'disputes', then this
+            attribute is required. If it is 'none', then this attribute is not allowed. 
           properties:
             primaryCode:
               type: string
@@ -53,10 +54,12 @@ $defs:
                 - SBS2
         evidenceOutcome:
           description: >-
-            The evidence outcome is a summary of the 'directionOfEvidenceProvided', 'strengthOfEvidenceProvided' and 'specifiedBy' values.
-            The 'specifiedBy' attribute is required and assumed to have a single method, OS2 or SBS2. if 'directionOfEvidenceProvided' 'none',
-            then the outcome is 'not met'. If 'directionOfEvidenceProvided' is 'supports' or 'disputes', then the outcome is 'met' along with
-            the strength of evidence provided.
+            The evidence outcome is a summary of the 'directionOfEvidenceProvided' and 'strengthOfEvidenceProvided' values, 
+            along with the specific criterion code used in these assessments. The indicated enumeration constrains the 
+            nested MappableConcept.primaryCoding > Coding.code attribute to capture evidence outcomes. Note that if 
+            'directionOfEvidenceProvided' is 'none', then the evidence outcome is 'not met' for the relevant criterion
+            (e.g. 'OS2_not_met'). If 'directionOfEvidenceProvided' is 'supports' or 'disputes', then the outcome is 'met' for
+            the relevant criterion, along with the strength of evidence provided. (e.g. 'OS2_moderate').
           properties:
             primaryCode:
               type: string


### PR DESCRIPTION
- updated language used to describe the evidenceOutcome attribute, which were referring to a specific 'specifiedBy' criterion code, but we no longer capture a specific code in the 'specifiedBy; field. This fix is essential.
- also updated the description of this attribute and 'strengthOfEvidenceProvided' to include language explaining the nesting of the enumerations defined for these attributes. These fixes are optional in my mind - but simply add some clarity around how.where the enumeration binding acts.