### PR TITLE
Add AAC constraints to therapeutic-response-study-statement-profile-s…

### DIFF
--- a/docs/source/community-profile-sets/index.rst
+++ b/docs/source/community-profile-sets/index.rst
@@ -76,7 +76,7 @@ A set of profiles defined to align with terminology and conventions from the Ass
 
 **Community Guideline:**
 
- - `AMP/ASCO/CAP (AAC) 2017 clinical interpretation guidleines <https://pubmed.ncbi.nlm.nih.gov/27993330/>`_
+ - `AMP/ASCO/CAP (AAC) 2017 clinical interpretation guidelines <https://pubmed.ncbi.nlm.nih.gov/27993330/>`_
 
 **Included Profiles**:
 

--- a/docs/source/va-standard-profiles/community-profiles/index.rst
+++ b/docs/source/va-standard-profiles/community-profiles/index.rst
@@ -7,7 +7,7 @@ Version 1 of the VA-Spec includes **Statement** and **Evidence Line** Community 
 
  - the `ACMG 2015 Pathogenicity Interpretation Guidelines <https://pubmed.ncbi.nlm.nih.gov/27993330/>`_
  - the `ClinGen/CGC/VICC (CCV) 2022 Oncogenicity Interpretation Guidelines <https://pubmed.ncbi.nlm.nih.gov/35101336/>`_
- - the `AMP/ASCO/CAP (AAC) Guidleines for Clinical Interpretation of Genetic Variants <https://pubmed.ncbi.nlm.nih.gov/25741868/>`_
+ - the `AMP/ASCO/CAP (AAC) Guidelines for Clinical Interpretation of Genetic Variants <https://pubmed.ncbi.nlm.nih.gov/25741868/>`_
 
 These Community Profiles layer additional constraints on top of VA core classes to enforce alignment with terminology conventions of a specific community guideline. For example, ACMG-based profiles define enumerations that incorporate ACMG terminology into value sets, including:
 

--- a/docs/source/va-standard-profiles/statement-profiles.rst
+++ b/docs/source/va-standard-profiles/statement-profiles.rst
@@ -3,7 +3,7 @@
 Statement Profiles
 !!!!!!!!!!!!!!!!!!
 
-Statement Profiles specialize the core ``Statement`` class to support a specific type of knowledge. The Statement profiles included in v1 of the VA-Spec are named and defined to align with curation and terminological conventions of established community guidelines in a given knowledge domain - such as the `ACMG 2015 Variant Interpretation Guidelines <https://pubmed.ncbi.nlm.nih.gov/27993330/>`_ for pathogenicity classifications, or the `AMP/ASCO/CAP (AAC) Guidleines <https://pubmed.ncbi.nlm.nih.gov/25741868/>`_ for clinical interpretation of genetic variants.
+Statement Profiles specialize the core ``Statement`` class to support a specific type of knowledge. The Statement profiles included in v1 of the VA-Spec are named and defined to align with curation and terminological conventions of established community guidelines in a given knowledge domain - such as the `ACMG 2015 Variant Interpretation Guidelines <https://pubmed.ncbi.nlm.nih.gov/27993330/>`_ for pathogenicity classifications, or the `AMP/ASCO/CAP (AAC) Guidelines <https://pubmed.ncbi.nlm.nih.gov/25741868/>`_ for clinical interpretation of genetic variants.
 
 .. _variant-pathogenicity-statement-acmg-2015:
 

--- a/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
@@ -40,8 +40,8 @@ $defs:
             primaryCoding:
               code:
                 enum:              # TO DO: Kori/Alex to populate value set here, as appropriate
-                  -                
-                  -  
+                  -
+                  -
                   -
               system:
                 const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
@@ -55,9 +55,9 @@ $defs:
             primaryCoding:
               code:
                 enum:              # TO DO: Kori/Alex to populate value set here, as approriate
-                  -                
-                  - 
-                  -  
+                  -
+                  -
+                  -
               system:
                 const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
         specifiedBy:
@@ -74,4 +74,4 @@ $defs:
           required:
             - reportedIn
       required:                   # TO DO: Kori/Alex to specify which, if any, attributes should be required here
-        -                         
+        -

--- a/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
@@ -55,14 +55,14 @@ $defs:
               allOf:
                 - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
                 - properties:
-                      code:
-                        enum:
-                          - Tier I
-                          - Tier II
-                          - Tier III
-                          - Tier IV
-                      system:
-                        const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+                    code:
+                      enum:
+                        - Tier I
+                        - Tier II
+                        - Tier III
+                        - Tier IV
+                    system:
+                      const: AMP/ASCO/CAP (AAC) Guidelines, 2017
         specifiedBy:
           description: >-
             A method that specifies how the diagnostic classification was ultimately assigned to the variant, based on assessment of

--- a/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
@@ -32,10 +32,7 @@ $defs:
           description: >-
             The strength of support that the Statement is determined to provide for or against the Diagnostic Proposition
             for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017
-            Guidelines. Note that the enumerated value set here is bound to the ‘code’ field of the Coding object that
-            is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
-            the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
-            'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
+            Guidelines.
           properties:
             primaryCoding:
               allOf:
@@ -59,9 +56,7 @@ $defs:
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
-            the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
-            enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
-            primary coding.
+            the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines.
           properties:
             primaryCoding:
               allOf:

--- a/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
@@ -28,3 +28,50 @@ $defs:
             A proposition about a diagnostic association between a variant and condition, for which the study provides
             evidence. The validity of this proposition, and the level of confidence/evidence supporting it,
             may be assessed and reported by the Statement.
+        strength:
+          description: >-
+            The strength of support that the Statement is determined to provide for or against the Diagnostic Proposition
+            for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017
+            Guidelines. Note that the enumerated value set here is bound to the ‘code’ field of the Coding object that
+            is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
+            the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
+            'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
+          properties:
+            primaryCoding:
+              code:
+                enum:              # TO DO: Kori/Alex to populate value set here, as appropriate
+                  -                
+                  -  
+                  -
+              system:
+                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+        classification:
+          description: >-
+            A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
+            the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
+            enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
+            primary coding.
+          properties:
+            primaryCoding:
+              code:
+                enum:              # TO DO: Kori/Alex to populate value set here, as approriate
+                  -                
+                  - 
+                  -  
+              system:
+                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+        specifiedBy:
+          description: >-
+            A method that specifies how the diagnostic classification was ultimately assigned to the variant, based on assessment of
+            evidence.
+          properties:
+            reportedIn:
+               properties:
+                  pmid:
+                    const: 27993330
+                  name:
+                    const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+          required:
+            - reportedIn
+      required:                   # TO DO: Kori/Alex to specify which, if any, attributes should be required here
+        -                         

--- a/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/aac-2017/diagnositc-study-statement-profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/aac-2017/diagnositc-study-statement-profile-source.yaml"
 title: Variant Diagnostic Study Statement Profile (AAC 2017)
 description: >-
   Profile defined to align with terminology and conventions from the Association for Molecular Pathology (AMP),
@@ -20,10 +20,10 @@ $defs:
       disease (diagnostic exclusion criterion) - based on interpretation of the study's
       results.
     allOf:
-    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
     - properties:
         proposition:
-          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantDiagnosticProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantDiagnosticProposition"
           description: >-
             A proposition about a diagnostic association between a variant and condition, for which the study provides
             evidence. The validity of this proposition, and the level of confidence/evidence supporting it,
@@ -36,42 +36,57 @@ $defs:
             is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
             the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
             'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
-          properties:
-            primaryCoding:
-              code:
-                enum:              # TO DO: Kori/Alex to populate value set here, as appropriate
-                  -
-                  -
-                  -
-              system:
-                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+          oneOf:
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Level A
+                    - Level B
+                    - Level C
+                    - Level D
+                system:
+                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Level E
+                system:
+                  const: CIViC SOP AAC Guidelines, 2019
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
             the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
             enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
             primary coding.
-          properties:
-            primaryCoding:
-              code:
-                enum:              # TO DO: Kori/Alex to populate value set here, as approriate
-                  -
-                  -
-                  -
-              system:
-                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+          oneOf:
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Tier I
+                    - Tier II
+                    - Tier III
+                    - Tier IV
+                system:
+                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+            required: [primaryCoding]
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Tier I - positive
+                    - Tier I - negative
+                    - Tier II - positive
+                    - Tier II - negative
+                system:
+                  const: CIViC SOP AAC Guidelines, 2019
+            required: [primaryCoding]
         specifiedBy:
           description: >-
             A method that specifies how the diagnostic classification was ultimately assigned to the variant, based on assessment of
             evidence.
-          properties:
-            reportedIn:
-               properties:
-                  pmid:
-                    const: 27993330
-                  name:
-                    const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
-          required:
-            - reportedIn
-      required:                   # TO DO: Kori/Alex to specify which, if any, attributes should be required here
-        -
+      required:
+        - classification
+        - specifiedBy

--- a/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
@@ -36,53 +36,59 @@ $defs:
             is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
             the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
             'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
-          oneOf:
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Level A
-                    - Level B
-                    - Level C
-                    - Level D
-                system:
-                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Level E
-                system:
-                  const: CIViC SOP AAC Guidelines, 2019
+          properties:
+            primaryCoding:
+              allOf:
+                - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                - oneOf:
+                  - properties:
+                        code:
+                          enum:
+                            - Level A
+                            - Level B
+                            - Level C
+                            - Level D
+                        system:
+                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+                  - properties:
+                        code:
+                          enum:
+                            - Level E
+                        system:
+                          const: CIViC SOP AAC Guidelines, 2019
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
             the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
             enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
             primary coding.
-          oneOf:
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Tier I
-                    - Tier II
-                    - Tier III
-                    - Tier IV
-                system:
-                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-            required: [primaryCoding]
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Tier I - positive
-                    - Tier I - negative
-                    - Tier II - positive
-                    - Tier II - negative
-                system:
-                  const: CIViC SOP AAC Guidelines, 2019
-            required: [primaryCoding]
+          properties:
+            primaryCoding:
+              allOf:
+                - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                - oneOf:
+                  - properties:
+                        code:
+                          enum:
+                            - Tier I
+                            - Tier II
+                            - Tier III
+                            - Tier IV
+                        system:
+                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+                  - properties:
+                        code:
+                          enum:
+                            - Tier I - Sensitivity/Response
+                            - Tier I - Resistance
+                            - Tier I - Adverse Response
+                            - Tier I - Reduced Response
+                            - Tier II - Sensitivity/Response
+                            - Tier II - Resistance
+                            - Tier II - Adverse Response
+                            - Tier II - Reduced Response
+                        system:
+                          const: CIViC SOP AAC Guidelines, 2019
         specifiedBy:
           description: >-
             A method that specifies how the diagnostic classification was ultimately assigned to the variant, based on assessment of

--- a/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/diagnostic-study-statement-profile-source.yaml
@@ -37,22 +37,15 @@ $defs:
             primaryCoding:
               allOf:
                 - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
-                - oneOf:
-                  - properties:
-                        code:
-                          enum:
-                            - Level A
-                            - Level B
-                            - Level C
-                            - Level D
-                        system:
-                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-                  - properties:
-                        code:
-                          enum:
-                            - Level E
-                        system:
-                          const: CIViC SOP AAC Guidelines, 2019
+                - properties:
+                      code:
+                        enum:
+                          - Level A
+                          - Level B
+                          - Level C
+                          - Level D
+                      system:
+                        const: AMP/ASCO/CAP (AAC) Guidelines, 2017
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
@@ -61,29 +54,15 @@ $defs:
             primaryCoding:
               allOf:
                 - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
-                - oneOf:
-                  - properties:
-                        code:
-                          enum:
-                            - Tier I
-                            - Tier II
-                            - Tier III
-                            - Tier IV
-                        system:
-                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-                  - properties:
-                        code:
-                          enum:
-                            - Tier I - Sensitivity/Response
-                            - Tier I - Resistance
-                            - Tier I - Adverse Response
-                            - Tier I - Reduced Response
-                            - Tier II - Sensitivity/Response
-                            - Tier II - Resistance
-                            - Tier II - Adverse Response
-                            - Tier II - Reduced Response
-                        system:
-                          const: CIViC SOP AAC Guidelines, 2019
+                - properties:
+                      code:
+                        enum:
+                          - Tier I
+                          - Tier II
+                          - Tier III
+                          - Tier IV
+                      system:
+                        const: AMP/ASCO/CAP (AAC) Guidelines, 2017
         specifiedBy:
           description: >-
             A method that specifies how the diagnostic classification was ultimately assigned to the variant, based on assessment of

--- a/schema/va-spec/aac-2017/json/VariantDiagnosticStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantDiagnosticStudyStatement
@@ -1,74 +1,107 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/aac-2017/json/VariantDiagnosticStudyStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/aac-2017/json/VariantDiagnosticStudyStatement",
    "title": "VariantDiagnosticStudyStatement",
    "description": "A statement reporting a conclusion from a single study about whether a variant is associated with a disease (a diagnostic inclusion criterion), or absence of a disease (diagnostic exclusion criterion) - based on interpretation of the study's results.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantDiagnosticProposition",
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantDiagnosticProposition",
                "description": "A proposition about a diagnostic association between a variant and condition, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
                "description": "The strength of support that the Statement is determined to provide for or against the Diagnostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
-               "properties": {
-                  "primaryCoding": {
-                     "code": {
-                        "enum": [
-                           null,
-                           null,
-                           null
-                        ]
-                     },
-                     "system": {
-                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
-                     }
-                  }
-               }
-            },
-            "classification": {
-               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
-               "properties": {
-                  "primaryCoding": {
-                     "code": {
-                        "enum": [
-                           null,
-                           null,
-                           null
-                        ]
-                     },
-                     "system": {
-                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
-                     }
-                  }
-               }
-            },
-            "specifiedBy": {
-               "description": "A method that specifies how the diagnostic classification was ultimately assigned to the variant, based on assessment of evidence.",
-               "properties": {
-                  "reportedIn": {
+               "oneOf": [
+                  {
                      "properties": {
-                        "pmid": {
-                           "const": 27993330
-                        },
-                        "name": {
-                           "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Level A",
+                                 "Level B",
+                                 "Level C",
+                                 "Level D"
+                              ]
+                           },
+                           "system": {
+                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                           }
+                        }
+                     }
+                  },
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Level E"
+                              ]
+                           },
+                           "system": {
+                              "const": "CIViC SOP AAC Guidelines, 2019"
+                           }
                         }
                      }
                   }
-               },
-               "required": [
-                  "reportedIn"
                ]
+            },
+            "classification": {
+               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
+               "oneOf": [
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Tier I",
+                                 "Tier II",
+                                 "Tier III",
+                                 "Tier IV"
+                              ]
+                           },
+                           "system": {
+                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                           }
+                        }
+                     },
+                     "required": [
+                        "primaryCoding"
+                     ]
+                  },
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Tier I - positive",
+                                 "Tier I - negative",
+                                 "Tier II - positive",
+                                 "Tier II - negative"
+                              ]
+                           },
+                           "system": {
+                              "const": "CIViC SOP AAC Guidelines, 2019"
+                           }
+                        }
+                     },
+                     "required": [
+                        "primaryCoding"
+                     ]
+                  }
+               ]
+            },
+            "specifiedBy": {
+               "description": "A method that specifies how the diagnostic classification was ultimately assigned to the variant, based on assessment of evidence."
             }
          },
          "required": [
-            null
+            "classification",
+            "specifiedBy"
          ]
       }
    ]

--- a/schema/va-spec/aac-2017/json/VariantDiagnosticStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantDiagnosticStudyStatement
@@ -15,7 +15,7 @@
                "description": "A proposition about a diagnostic association between a variant and condition, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
-               "description": "The strength of support that the Statement is determined to provide for or against the Diagnostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
+               "description": "The strength of support that the Statement is determined to provide for or against the Diagnostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines.",
                "properties": {
                   "primaryCoding": {
                      "allOf": [
@@ -23,42 +23,26 @@
                            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
                         },
                         {
-                           "oneOf": [
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Level A",
-                                          "Level B",
-                                          "Level C",
-                                          "Level D"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                                    }
-                                 }
+                           "properties": {
+                              "code": {
+                                 "enum": [
+                                    "Level A",
+                                    "Level B",
+                                    "Level C",
+                                    "Level D"
+                                 ]
                               },
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Level E"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "CIViC SOP AAC Guidelines, 2019"
-                                    }
-                                 }
+                              "system": {
+                                 "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
                               }
-                           ]
+                           }
                         }
                      ]
                   }
                }
             },
             "classification": {
-               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
+               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines.",
                "properties": {
                   "primaryCoding": {
                      "allOf": [
@@ -66,42 +50,19 @@
                            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
                         },
                         {
-                           "oneOf": [
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Tier I",
-                                          "Tier II",
-                                          "Tier III",
-                                          "Tier IV"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                                    }
-                                 }
+                           "properties": {
+                              "code": {
+                                 "enum": [
+                                    "Tier I",
+                                    "Tier II",
+                                    "Tier III",
+                                    "Tier IV"
+                                 ]
                               },
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Tier I - Sensitivity/Response",
-                                          "Tier I - Resistance",
-                                          "Tier I - Adverse Response",
-                                          "Tier I - Reduced Response",
-                                          "Tier II - Sensitivity/Response",
-                                          "Tier II - Resistance",
-                                          "Tier II - Adverse Response",
-                                          "Tier II - Reduced Response"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "CIViC SOP AAC Guidelines, 2019"
-                                    }
-                                 }
+                              "system": {
+                                 "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
                               }
-                           ]
+                           }
                         }
                      ]
                   }

--- a/schema/va-spec/aac-2017/json/VariantDiagnosticStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantDiagnosticStudyStatement
@@ -16,84 +16,96 @@
             },
             "strength": {
                "description": "The strength of support that the Statement is determined to provide for or against the Diagnostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
-               "oneOf": [
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Level A",
-                                 "Level B",
-                                 "Level C",
-                                 "Level D"
-                              ]
-                           },
-                           "system": {
-                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                           }
+               "properties": {
+                  "primaryCoding": {
+                     "allOf": [
+                        {
+                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                        },
+                        {
+                           "oneOf": [
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Level A",
+                                          "Level B",
+                                          "Level C",
+                                          "Level D"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                                    }
+                                 }
+                              },
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Level E"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "CIViC SOP AAC Guidelines, 2019"
+                                    }
+                                 }
+                              }
+                           ]
                         }
-                     }
-                  },
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Level E"
-                              ]
-                           },
-                           "system": {
-                              "const": "CIViC SOP AAC Guidelines, 2019"
-                           }
-                        }
-                     }
+                     ]
                   }
-               ]
+               }
             },
             "classification": {
                "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
-               "oneOf": [
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Tier I",
-                                 "Tier II",
-                                 "Tier III",
-                                 "Tier IV"
-                              ]
-                           },
-                           "system": {
-                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                           }
+               "properties": {
+                  "primaryCoding": {
+                     "allOf": [
+                        {
+                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                        },
+                        {
+                           "oneOf": [
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Tier I",
+                                          "Tier II",
+                                          "Tier III",
+                                          "Tier IV"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                                    }
+                                 }
+                              },
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Tier I - Sensitivity/Response",
+                                          "Tier I - Resistance",
+                                          "Tier I - Adverse Response",
+                                          "Tier I - Reduced Response",
+                                          "Tier II - Sensitivity/Response",
+                                          "Tier II - Resistance",
+                                          "Tier II - Adverse Response",
+                                          "Tier II - Reduced Response"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "CIViC SOP AAC Guidelines, 2019"
+                                    }
+                                 }
+                              }
+                           ]
                         }
-                     },
-                     "required": [
-                        "primaryCoding"
-                     ]
-                  },
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Tier I - positive",
-                                 "Tier I - negative",
-                                 "Tier II - positive",
-                                 "Tier II - negative"
-                              ]
-                           },
-                           "system": {
-                              "const": "CIViC SOP AAC Guidelines, 2019"
-                           }
-                        }
-                     },
-                     "required": [
-                        "primaryCoding"
                      ]
                   }
-               ]
+               }
             },
             "specifiedBy": {
                "description": "A method that specifies how the diagnostic classification was ultimately assigned to the variant, based on assessment of evidence."

--- a/schema/va-spec/aac-2017/json/VariantDiagnosticStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantDiagnosticStudyStatement
@@ -13,8 +13,63 @@
             "proposition": {
                "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantDiagnosticProposition",
                "description": "A proposition about a diagnostic association between a variant and condition, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
+            },
+            "strength": {
+               "description": "The strength of support that the Statement is determined to provide for or against the Diagnostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
+               "properties": {
+                  "primaryCoding": {
+                     "code": {
+                        "enum": [
+                           null,
+                           null,
+                           null
+                        ]
+                     },
+                     "system": {
+                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                     }
+                  }
+               }
+            },
+            "classification": {
+               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
+               "properties": {
+                  "primaryCoding": {
+                     "code": {
+                        "enum": [
+                           null,
+                           null,
+                           null
+                        ]
+                     },
+                     "system": {
+                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                     }
+                  }
+               }
+            },
+            "specifiedBy": {
+               "description": "A method that specifies how the diagnostic classification was ultimately assigned to the variant, based on assessment of evidence.",
+               "properties": {
+                  "reportedIn": {
+                     "properties": {
+                        "pmid": {
+                           "const": 27993330
+                        },
+                        "name": {
+                           "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                        }
+                     }
+                  }
+               },
+               "required": [
+                  "reportedIn"
+               ]
             }
-         }
+         },
+         "required": [
+            null
+         ]
       }
    ]
 }

--- a/schema/va-spec/aac-2017/json/VariantPrognosticStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantPrognosticStudyStatement
@@ -1,74 +1,101 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/aac-2017/json/VariantPrognosticStudyStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/aac-2017/json/VariantPrognosticStudyStatement",
    "title": "VariantPrognosticStudyStatement",
    "description": "A statement reporting a conclusion from a single study about whether a variant is associated with a disease prognosis - based on interpretation of the study's results.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPrognosticProposition",
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPrognosticProposition",
                "description": "A proposition about a prognostic association between a variant and condition, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
                "description": "The strength of support that the Statement is determined to provide for or against the Prognostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
-               "properties": {
-                  "primaryCoding": {
-                     "code": {
-                        "enum": [
-                           null,
-                           null,
-                           null
-                        ]
-                     },
-                     "system": {
-                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
-                     }
-                  }
-               }
-            },
-            "classification": {
-               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
-               "properties": {
-                  "primaryCoding": {
-                     "code": {
-                        "enum": [
-                           null,
-                           null,
-                           null
-                        ]
-                     },
-                     "system": {
-                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
-                     }
-                  }
-               }
-            },
-            "specifiedBy": {
-               "description": "A method that specifies how the prognostic classification was ultimately assigned to the variant, based on assessment of evidence.",
-               "properties": {
-                  "reportedIn": {
+               "oneOf": [
+                  {
                      "properties": {
-                        "pmid": {
-                           "const": 27993330
-                        },
-                        "name": {
-                           "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Level A",
+                                 "Level B",
+                                 "Level C",
+                                 "Level D"
+                              ]
+                           },
+                           "system": {
+                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                           }
+                        }
+                     }
+                  },
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Level E"
+                              ]
+                           },
+                           "system": {
+                              "const": "CIViC SOP AAC Guidelines, 2019"
+                           }
                         }
                      }
                   }
-               },
-               "required": [
-                  "reportedIn"
                ]
+            },
+            "classification": {
+               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
+               "oneOf": [
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Tier I",
+                                 "Tier II",
+                                 "Tier III",
+                                 "Tier IV"
+                              ]
+                           },
+                           "system": {
+                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                           }
+                        }
+                     }
+                  },
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Tier I - Better Outcome",
+                                 "Tier I - Poor Outcome",
+                                 "Tier II - Better Outcome",
+                                 "Tier II - Poor Outcome"
+                              ]
+                           },
+                           "system": {
+                              "const": "CIViC SOP AAC Guidelines, 2019"
+                           }
+                        }
+                     }
+                  }
+               ]
+            },
+            "specifiedBy": {
+               "description": "A method that specifies how the prognostic classification was ultimately assigned to the variant, based on assessment of evidence."
             }
          },
          "required": [
-            null
+            "classification",
+            "specifiedBy"
          ]
       }
    ]

--- a/schema/va-spec/aac-2017/json/VariantPrognosticStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantPrognosticStudyStatement
@@ -15,7 +15,7 @@
                "description": "A proposition about a prognostic association between a variant and condition, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
-               "description": "The strength of support that the Statement is determined to provide for or against the Prognostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
+               "description": "The strength of support that the Statement is determined to provide for or against the Prognostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines.",
                "properties": {
                   "primaryCoding": {
                      "allOf": [
@@ -23,35 +23,19 @@
                            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
                         },
                         {
-                           "oneOf": [
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Level A",
-                                          "Level B",
-                                          "Level C",
-                                          "Level D"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                                    }
-                                 }
+                           "properties": {
+                              "code": {
+                                 "enum": [
+                                    "Level A",
+                                    "Level B",
+                                    "Level C",
+                                    "Level D"
+                                 ]
                               },
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Level E"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "CIViC SOP AAC Guidelines, 2019"
-                                    }
-                                 }
+                              "system": {
+                                 "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
                               }
-                           ]
+                           }
                         }
                      ]
                   }
@@ -66,42 +50,19 @@
                            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
                         },
                         {
-                           "oneOf": [
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Tier I",
-                                          "Tier II",
-                                          "Tier III",
-                                          "Tier IV"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                                    }
-                                 }
+                           "properties": {
+                              "code": {
+                                 "enum": [
+                                    "Tier I",
+                                    "Tier II",
+                                    "Tier III",
+                                    "Tier IV"
+                                 ]
                               },
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Tier I - Sensitivity/Response",
-                                          "Tier I - Resistance",
-                                          "Tier I - Adverse Response",
-                                          "Tier I - Reduced Response",
-                                          "Tier II - Sensitivity/Response",
-                                          "Tier II - Resistance",
-                                          "Tier II - Adverse Response",
-                                          "Tier II - Reduced Response"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "CIViC SOP AAC Guidelines, 2019"
-                                    }
-                                 }
+                              "system": {
+                                 "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
                               }
-                           ]
+                           }
                         }
                      ]
                   }

--- a/schema/va-spec/aac-2017/json/VariantPrognosticStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantPrognosticStudyStatement
@@ -16,78 +16,96 @@
             },
             "strength": {
                "description": "The strength of support that the Statement is determined to provide for or against the Prognostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
-               "oneOf": [
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Level A",
-                                 "Level B",
-                                 "Level C",
-                                 "Level D"
-                              ]
-                           },
-                           "system": {
-                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                           }
+               "properties": {
+                  "primaryCoding": {
+                     "allOf": [
+                        {
+                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                        },
+                        {
+                           "oneOf": [
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Level A",
+                                          "Level B",
+                                          "Level C",
+                                          "Level D"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                                    }
+                                 }
+                              },
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Level E"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "CIViC SOP AAC Guidelines, 2019"
+                                    }
+                                 }
+                              }
+                           ]
                         }
-                     }
-                  },
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Level E"
-                              ]
-                           },
-                           "system": {
-                              "const": "CIViC SOP AAC Guidelines, 2019"
-                           }
-                        }
-                     }
+                     ]
                   }
-               ]
+               }
             },
             "classification": {
                "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
-               "oneOf": [
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Tier I",
-                                 "Tier II",
-                                 "Tier III",
-                                 "Tier IV"
-                              ]
-                           },
-                           "system": {
-                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                           }
+               "properties": {
+                  "primaryCoding": {
+                     "allOf": [
+                        {
+                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                        },
+                        {
+                           "oneOf": [
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Tier I",
+                                          "Tier II",
+                                          "Tier III",
+                                          "Tier IV"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                                    }
+                                 }
+                              },
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Tier I - Sensitivity/Response",
+                                          "Tier I - Resistance",
+                                          "Tier I - Adverse Response",
+                                          "Tier I - Reduced Response",
+                                          "Tier II - Sensitivity/Response",
+                                          "Tier II - Resistance",
+                                          "Tier II - Adverse Response",
+                                          "Tier II - Reduced Response"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "CIViC SOP AAC Guidelines, 2019"
+                                    }
+                                 }
+                              }
+                           ]
                         }
-                     }
-                  },
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Tier I - Better Outcome",
-                                 "Tier I - Poor Outcome",
-                                 "Tier II - Better Outcome",
-                                 "Tier II - Poor Outcome"
-                              ]
-                           },
-                           "system": {
-                              "const": "CIViC SOP AAC Guidelines, 2019"
-                           }
-                        }
-                     }
+                     ]
                   }
-               ]
+               }
             },
             "specifiedBy": {
                "description": "A method that specifies how the prognostic classification was ultimately assigned to the variant, based on assessment of evidence."

--- a/schema/va-spec/aac-2017/json/VariantPrognosticStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantPrognosticStudyStatement
@@ -13,8 +13,63 @@
             "proposition": {
                "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPrognosticProposition",
                "description": "A proposition about a prognostic association between a variant and condition, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
+            },
+            "strength": {
+               "description": "The strength of support that the Statement is determined to provide for or against the Prognostic Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
+               "properties": {
+                  "primaryCoding": {
+                     "code": {
+                        "enum": [
+                           null,
+                           null,
+                           null
+                        ]
+                     },
+                     "system": {
+                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                     }
+                  }
+               }
+            },
+            "classification": {
+               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
+               "properties": {
+                  "primaryCoding": {
+                     "code": {
+                        "enum": [
+                           null,
+                           null,
+                           null
+                        ]
+                     },
+                     "system": {
+                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                     }
+                  }
+               }
+            },
+            "specifiedBy": {
+               "description": "A method that specifies how the prognostic classification was ultimately assigned to the variant, based on assessment of evidence.",
+               "properties": {
+                  "reportedIn": {
+                     "properties": {
+                        "pmid": {
+                           "const": 27993330
+                        },
+                        "name": {
+                           "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                        }
+                     }
+                  }
+               },
+               "required": [
+                  "reportedIn"
+               ]
             }
-         }
+         },
+         "required": [
+            null
+         ]
       }
    ]
 }

--- a/schema/va-spec/aac-2017/json/VariantTherapeuticResponseStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantTherapeuticResponseStudyStatement
@@ -15,7 +15,7 @@
                "description": "A proposition about the therapeutic response associated with a variant, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
-               "description": "The strength of support that the Statement is determined to provide for or against the Therapeutic Response Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
+               "description": "The strength of support that the Statement is determined to provide for or against the Therapeutic Response Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines.",
                "properties": {
                   "primaryCoding": {
                      "allOf": [
@@ -23,42 +23,26 @@
                            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
                         },
                         {
-                           "oneOf": [
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Level A",
-                                          "Level B",
-                                          "Level C",
-                                          "Level D"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                                    }
-                                 }
+                           "properties": {
+                              "code": {
+                                 "enum": [
+                                    "Level A",
+                                    "Level B",
+                                    "Level C",
+                                    "Level D"
+                                 ]
                               },
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Level E"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "CIViC SOP AAC Guidelines, 2019"
-                                    }
-                                 }
+                              "system": {
+                                 "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
                               }
-                           ]
+                           }
                         }
                      ]
                   }
                }
             },
             "classification": {
-               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
+               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines.",
                "properties": {
                   "primaryCoding": {
                      "allOf": [
@@ -66,42 +50,19 @@
                            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
                         },
                         {
-                           "oneOf": [
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Tier I",
-                                          "Tier II",
-                                          "Tier III",
-                                          "Tier IV"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                                    }
-                                 }
+                           "properties": {
+                              "code": {
+                                 "enum": [
+                                    "Tier I",
+                                    "Tier II",
+                                    "Tier III",
+                                    "Tier IV"
+                                 ]
                               },
-                              {
-                                 "properties": {
-                                    "code": {
-                                       "enum": [
-                                          "Tier I - Sensitivity/Response",
-                                          "Tier I - Resistance",
-                                          "Tier I - Adverse Response",
-                                          "Tier I - Reduced Response",
-                                          "Tier II - Sensitivity/Response",
-                                          "Tier II - Resistance",
-                                          "Tier II - Adverse Response",
-                                          "Tier II - Reduced Response"
-                                       ]
-                                    },
-                                    "system": {
-                                       "const": "CIViC SOP AAC Guidelines, 2019"
-                                    }
-                                 }
+                              "system": {
+                                 "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
                               }
-                           ]
+                           }
                         }
                      ]
                   }

--- a/schema/va-spec/aac-2017/json/VariantTherapeuticResponseStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantTherapeuticResponseStudyStatement
@@ -13,8 +13,63 @@
             "proposition": {
                "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantTherapeuticResponseProposition",
                "description": "A proposition about the therapeutic response associated with a variant, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
+            },
+            "strength": {
+               "description": "The strength of support that the Statement is determined to provide for or against the Therapeutic Response Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
+               "properties": {
+                  "primaryCoding": {
+                     "code": {
+                        "enum": [
+                           null,
+                           null,
+                           null
+                        ]
+                     },
+                     "system": {
+                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                     }
+                  }
+               }
+            },
+            "classification": {
+               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
+               "properties": {
+                  "primaryCoding": {
+                     "code": {
+                        "enum": [
+                           null,
+                           null,
+                           null
+                        ]
+                     },
+                     "system": {
+                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                     }
+                  }
+               }
+            },
+            "specifiedBy": {
+               "description": "A method that specifies how the therapeutic response classification was ultimately assigned to the variant, based on assessment of evidence.",
+               "properties": {
+                  "reportedIn": {
+                     "properties": {
+                        "pmid": {
+                           "const": 27993330
+                        },
+                        "name": {
+                           "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                        }
+                     }
+                  }
+               },
+               "required": [
+                  "reportedIn"
+               ]
             }
-         }
+         },
+         "required": [
+            null
+         ]
       }
    ]
 }

--- a/schema/va-spec/aac-2017/json/VariantTherapeuticResponseStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantTherapeuticResponseStudyStatement
@@ -1,74 +1,105 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/aac-2017/json/VariantTherapeuticResponseStudyStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/aac-2017/json/VariantTherapeuticResponseStudyStatement",
    "title": "VariantTherapeuticResponseStudyStatement",
    "description": "A statement reporting a conclusion from a single study about whether a variant is associated with a therapeutic response (positive or negative) - based on interpretation of the study's results.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantTherapeuticResponseProposition",
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantTherapeuticResponseProposition",
                "description": "A proposition about the therapeutic response associated with a variant, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
                "description": "The strength of support that the Statement is determined to provide for or against the Therapeutic Response Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
-               "properties": {
-                  "primaryCoding": {
-                     "code": {
-                        "enum": [
-                           null,
-                           null,
-                           null
-                        ]
-                     },
-                     "system": {
-                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
-                     }
-                  }
-               }
-            },
-            "classification": {
-               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
-               "properties": {
-                  "primaryCoding": {
-                     "code": {
-                        "enum": [
-                           null,
-                           null,
-                           null
-                        ]
-                     },
-                     "system": {
-                        "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
-                     }
-                  }
-               }
-            },
-            "specifiedBy": {
-               "description": "A method that specifies how the therapeutic response classification was ultimately assigned to the variant, based on assessment of evidence.",
-               "properties": {
-                  "reportedIn": {
+               "oneOf": [
+                  {
                      "properties": {
-                        "pmid": {
-                           "const": 27993330
-                        },
-                        "name": {
-                           "const": "AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017"
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Level A",
+                                 "Level B",
+                                 "Level C",
+                                 "Level D"
+                              ]
+                           },
+                           "system": {
+                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                           }
+                        }
+                     }
+                  },
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Level E"
+                              ]
+                           },
+                           "system": {
+                              "const": "CIViC SOP AAC Guidelines, 2019"
+                           }
                         }
                      }
                   }
-               },
-               "required": [
-                  "reportedIn"
                ]
+            },
+            "classification": {
+               "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
+               "oneOf": [
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Tier I",
+                                 "Tier II",
+                                 "Tier III",
+                                 "Tier IV"
+                              ]
+                           },
+                           "system": {
+                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                           }
+                        }
+                     }
+                  },
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "Tier I - Sensitivity/Response",
+                                 "Tier I - Resistance",
+                                 "Tier I - Adverse Response",
+                                 "Tier I - Reduced Response",
+                                 "Tier II - Sensitivity/Response",
+                                 "Tier II - Resistance",
+                                 "Tier II - Adverse Response",
+                                 "Tier II - Reduced Response"
+                              ]
+                           },
+                           "system": {
+                              "const": "CIViC SOP AAC Guidelines, 2019"
+                           }
+                        }
+                     }
+                  }
+               ]
+            },
+            "specifiedBy": {
+               "description": "A method that specifies how the therapeutic response classification was ultimately assigned to the variant, based on assessment of evidence."
             }
          },
          "required": [
-            null
+            "classification",
+            "specifiedBy"
          ]
       }
    ]

--- a/schema/va-spec/aac-2017/json/VariantTherapeuticResponseStudyStatement
+++ b/schema/va-spec/aac-2017/json/VariantTherapeuticResponseStudyStatement
@@ -16,82 +16,96 @@
             },
             "strength": {
                "description": "The strength of support that the Statement is determined to provide for or against the Therapeutic Response Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the 'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.",
-               "oneOf": [
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Level A",
-                                 "Level B",
-                                 "Level C",
-                                 "Level D"
-                              ]
-                           },
-                           "system": {
-                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                           }
+               "properties": {
+                  "primaryCoding": {
+                     "allOf": [
+                        {
+                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                        },
+                        {
+                           "oneOf": [
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Level A",
+                                          "Level B",
+                                          "Level C",
+                                          "Level D"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                                    }
+                                 }
+                              },
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Level E"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "CIViC SOP AAC Guidelines, 2019"
+                                    }
+                                 }
+                              }
+                           ]
                         }
-                     }
-                  },
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Level E"
-                              ]
-                           },
-                           "system": {
-                              "const": "CIViC SOP AAC Guidelines, 2019"
-                           }
-                        }
-                     }
+                     ]
                   }
-               ]
+               }
             },
             "classification": {
                "description": "A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the enumerated value set here is bound to the \u2018code\u2019 field of the Coding object that is nested inside a MappableConcept's primary coding.",
-               "oneOf": [
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Tier I",
-                                 "Tier II",
-                                 "Tier III",
-                                 "Tier IV"
-                              ]
-                           },
-                           "system": {
-                              "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
-                           }
+               "properties": {
+                  "primaryCoding": {
+                     "allOf": [
+                        {
+                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                        },
+                        {
+                           "oneOf": [
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Tier I",
+                                          "Tier II",
+                                          "Tier III",
+                                          "Tier IV"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+                                    }
+                                 }
+                              },
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "Tier I - Sensitivity/Response",
+                                          "Tier I - Resistance",
+                                          "Tier I - Adverse Response",
+                                          "Tier I - Reduced Response",
+                                          "Tier II - Sensitivity/Response",
+                                          "Tier II - Resistance",
+                                          "Tier II - Adverse Response",
+                                          "Tier II - Reduced Response"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "CIViC SOP AAC Guidelines, 2019"
+                                    }
+                                 }
+                              }
+                           ]
                         }
-                     }
-                  },
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "Tier I - Sensitivity/Response",
-                                 "Tier I - Resistance",
-                                 "Tier I - Adverse Response",
-                                 "Tier I - Reduced Response",
-                                 "Tier II - Sensitivity/Response",
-                                 "Tier II - Resistance",
-                                 "Tier II - Adverse Response",
-                                 "Tier II - Reduced Response"
-                              ]
-                           },
-                           "system": {
-                              "const": "CIViC SOP AAC Guidelines, 2019"
-                           }
-                        }
-                     }
+                     ]
                   }
-               ]
+               }
             },
             "specifiedBy": {
                "description": "A method that specifies how the therapeutic response classification was ultimately assigned to the variant, based on assessment of evidence."

--- a/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
@@ -31,30 +31,20 @@ $defs:
           description: >-
             The strength of support that the Statement is determined to provide for or against the Prognostic Proposition
             for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017
-            Guidelines. Note that the enumerated value set here is bound to the ‘code’ field of the Coding object that
-            is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
-            the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
-            'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
+            Guidelines.
           properties:
             primaryCoding:
               allOf:
                 - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
-                - oneOf:
-                  - properties:
-                        code:
-                          enum:
-                            - Level A
-                            - Level B
-                            - Level C
-                            - Level D
-                        system:
-                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-                  - properties:
-                        code:
-                          enum:
-                            - Level E
-                        system:
-                          const: CIViC SOP AAC Guidelines, 2019
+                - properties:
+                    code:
+                      enum:
+                        - Level A
+                        - Level B
+                        - Level C
+                        - Level D
+                    system:
+                      const: AMP/ASCO/CAP (AAC) Guidelines, 2017
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
@@ -65,29 +55,15 @@ $defs:
             primaryCoding:
               allOf:
                 - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
-                - oneOf:
-                  - properties:
-                        code:
-                          enum:
-                            - Tier I
-                            - Tier II
-                            - Tier III
-                            - Tier IV
-                        system:
-                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-                  - properties:
-                        code:
-                          enum:
-                            - Tier I - Sensitivity/Response
-                            - Tier I - Resistance
-                            - Tier I - Adverse Response
-                            - Tier I - Reduced Response
-                            - Tier II - Sensitivity/Response
-                            - Tier II - Resistance
-                            - Tier II - Adverse Response
-                            - Tier II - Reduced Response
-                        system:
-                          const: CIViC SOP AAC Guidelines, 2019
+                - properties:
+                    code:
+                      enum:
+                        - Tier I
+                        - Tier II
+                        - Tier III
+                        - Tier IV
+                    system:
+                      const: AMP/ASCO/CAP (AAC) Guidelines, 2017
         specifiedBy:
           description: >-
             A method that specifies how the prognostic classification was ultimately assigned to the variant, based on assessment of

--- a/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
@@ -39,8 +39,8 @@ $defs:
             primaryCoding:
               code:
                 enum:              # TO DO: Kori/Alex to populate value set here, as appropriate
-                  -                
-                  -  
+                  -
+                  -
                   -
               system:
                 const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
@@ -54,9 +54,9 @@ $defs:
             primaryCoding:
               code:
                 enum:              # TO DO: Kori/Alex to populate value set here, as approriate
-                  -                
-                  - 
-                  -  
+                  -
+                  -
+                  -
               system:
                 const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
         specifiedBy:
@@ -73,4 +73,4 @@ $defs:
           required:
             - reportedIn
       required:                   # TO DO: Kori/Alex to specify which, if any, attributes should be required here
-        -                         
+        -

--- a/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/aac-2017/prognostic-study-statement-profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/aac-2017/prognostic-study-statement-profile-source.yaml"
 title: Variant Prognostic Study Statement Profile (AAC 2017)
 description: >-
   Profile defined to align with terminology and conventions from the Association for Molecular Pathology (AMP),
@@ -19,10 +19,10 @@ $defs:
       is associated with a disease prognosis - based on interpretation of the study's
       results.
     allOf:
-    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
     - properties:
         proposition:
-          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPrognosticProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPrognosticProposition"
           description: >-
             A proposition about a prognostic association between a variant and condition, for which the study provides
             evidence. The validity of this proposition, and the level of confidence/evidence supporting it,
@@ -35,42 +35,55 @@ $defs:
             is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
             the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
             'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
-          properties:
-            primaryCoding:
-              code:
-                enum:              # TO DO: Kori/Alex to populate value set here, as appropriate
-                  -
-                  -
-                  -
-              system:
-                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+          oneOf:
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Level A
+                    - Level B
+                    - Level C
+                    - Level D
+                system:
+                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Level E
+                system:
+                  const: CIViC SOP AAC Guidelines, 2019
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
             the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
             enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
             primary coding.
-          properties:
-            primaryCoding:
-              code:
-                enum:              # TO DO: Kori/Alex to populate value set here, as approriate
-                  -
-                  -
-                  -
-              system:
-                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+          oneOf:
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Tier I
+                    - Tier II
+                    - Tier III
+                    - Tier IV
+                system:
+                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Tier I - Better Outcome
+                    - Tier I - Poor Outcome
+                    - Tier II - Better Outcome
+                    - Tier II - Poor Outcome
+                system:
+                  const: CIViC SOP AAC Guidelines, 2019
         specifiedBy:
           description: >-
             A method that specifies how the prognostic classification was ultimately assigned to the variant, based on assessment of
             evidence.
-          properties:
-            reportedIn:
-               properties:
-                  pmid:
-                    const: 27993330
-                  name:
-                    const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
-          required:
-            - reportedIn
-      required:                   # TO DO: Kori/Alex to specify which, if any, attributes should be required here
-        -
+      required:
+        - classification
+        - specifiedBy

--- a/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
@@ -35,51 +35,59 @@ $defs:
             is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
             the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
             'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
-          oneOf:
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Level A
-                    - Level B
-                    - Level C
-                    - Level D
-                system:
-                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Level E
-                system:
-                  const: CIViC SOP AAC Guidelines, 2019
+          properties:
+            primaryCoding:
+              allOf:
+                - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                - oneOf:
+                  - properties:
+                        code:
+                          enum:
+                            - Level A
+                            - Level B
+                            - Level C
+                            - Level D
+                        system:
+                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+                  - properties:
+                        code:
+                          enum:
+                            - Level E
+                        system:
+                          const: CIViC SOP AAC Guidelines, 2019
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
             the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
             enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
             primary coding.
-          oneOf:
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Tier I
-                    - Tier II
-                    - Tier III
-                    - Tier IV
-                system:
-                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Tier I - Better Outcome
-                    - Tier I - Poor Outcome
-                    - Tier II - Better Outcome
-                    - Tier II - Poor Outcome
-                system:
-                  const: CIViC SOP AAC Guidelines, 2019
+          properties:
+            primaryCoding:
+              allOf:
+                - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                - oneOf:
+                  - properties:
+                        code:
+                          enum:
+                            - Tier I
+                            - Tier II
+                            - Tier III
+                            - Tier IV
+                        system:
+                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+                  - properties:
+                        code:
+                          enum:
+                            - Tier I - Sensitivity/Response
+                            - Tier I - Resistance
+                            - Tier I - Adverse Response
+                            - Tier I - Reduced Response
+                            - Tier II - Sensitivity/Response
+                            - Tier II - Resistance
+                            - Tier II - Adverse Response
+                            - Tier II - Reduced Response
+                        system:
+                          const: CIViC SOP AAC Guidelines, 2019
         specifiedBy:
           description: >-
             A method that specifies how the prognostic classification was ultimately assigned to the variant, based on assessment of

--- a/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/prognostic-study-statement-profile-source.yaml
@@ -27,3 +27,50 @@ $defs:
             A proposition about a prognostic association between a variant and condition, for which the study provides
             evidence. The validity of this proposition, and the level of confidence/evidence supporting it,
             may be assessed and reported by the Statement.
+        strength:
+          description: >-
+            The strength of support that the Statement is determined to provide for or against the Prognostic Proposition
+            for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC) 2017
+            Guidelines. Note that the enumerated value set here is bound to the ‘code’ field of the Coding object that
+            is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
+            the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
+            'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
+          properties:
+            primaryCoding:
+              code:
+                enum:              # TO DO: Kori/Alex to populate value set here, as appropriate
+                  -                
+                  -  
+                  -
+              system:
+                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+        classification:
+          description: >-
+            A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
+            the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
+            enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
+            primary coding.
+          properties:
+            primaryCoding:
+              code:
+                enum:              # TO DO: Kori/Alex to populate value set here, as approriate
+                  -                
+                  - 
+                  -  
+              system:
+                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+        specifiedBy:
+          description: >-
+            A method that specifies how the prognostic classification was ultimately assigned to the variant, based on assessment of
+            evidence.
+          properties:
+            reportedIn:
+               properties:
+                  pmid:
+                    const: 27993330
+                  name:
+                    const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+          required:
+            - reportedIn
+      required:                   # TO DO: Kori/Alex to specify which, if any, attributes should be required here
+        -                         

--- a/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
@@ -35,55 +35,59 @@ $defs:
             is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
             the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
             'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
-          oneOf:
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Level A
-                    - Level B
-                    - Level C
-                    - Level D
-                system:
-                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Level E
-                system:
-                  const: CIViC SOP AAC Guidelines, 2019
+          properties:
+            primaryCoding:
+              allOf:
+                - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                - oneOf:
+                  - properties:
+                        code:
+                          enum:
+                            - Level A
+                            - Level B
+                            - Level C
+                            - Level D
+                        system:
+                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+                  - properties:
+                        code:
+                          enum:
+                            - Level E
+                        system:
+                          const: CIViC SOP AAC Guidelines, 2019
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
             the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
             enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
             primary coding.
-          oneOf:
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Tier I
-                    - Tier II
-                    - Tier III
-                    - Tier IV
-                system:
-                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - Tier I - Sensitivity/Response
-                    - Tier I - Resistance
-                    - Tier I - Adverse Response
-                    - Tier I - Reduced Response
-                    - Tier II - Sensitivity/Response
-                    - Tier II - Resistance
-                    - Tier II - Adverse Response
-                    - Tier II - Reduced Response
-                system:
-                  const: CIViC SOP AAC Guidelines, 2019
+          properties:
+            primaryCoding:
+              allOf:
+                - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                - oneOf:
+                  - properties:
+                        code:
+                          enum:
+                            - Tier I
+                            - Tier II
+                            - Tier III
+                            - Tier IV
+                        system:
+                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+                  - properties:
+                        code:
+                          enum:
+                            - Tier I - Sensitivity/Response
+                            - Tier I - Resistance
+                            - Tier I - Adverse Response
+                            - Tier I - Reduced Response
+                            - Tier II - Sensitivity/Response
+                            - Tier II - Resistance
+                            - Tier II - Adverse Response
+                            - Tier II - Reduced Response
+                        system:
+                          const: CIViC SOP AAC Guidelines, 2019
         specifiedBy:
           description: >-
             A method that specifies how the therapeutic response classification was ultimately assigned to the variant,

--- a/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
@@ -27,3 +27,48 @@ $defs:
             A proposition about the therapeutic response associated with a variant, for which the study provides
             evidence. The validity of this proposition, and the level of confidence/evidence supporting it,
             may be assessed and reported by the Statement.
+        strength:
+          description: >-
+            The strength of support that the Therapeutic Response statement is determined to provide
+            for or against the reported therapeutic response association of the assessed variant - based on the
+            AMP/ASCO/CAP (AAC) 2017 Guidleines.  The enumerated value set here is bound to the ‘code’ field in the
+            Coding object nested inside a MappableConcept. Conditional requirement: Strength is evaluated relative
+            to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', 
+            then this attribute is required.  If it is 'neutral', then this attribute is not allowed.
+          properties:
+            primaryCoding:
+              code:
+                enum:
+                  -                 # TO DO: Kori/Alex to populate value set here, as appropriate
+                  -  
+                  -
+              system:
+                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+        classification:
+          description: >-
+            The classification of the variant's therapeutic response association, based on the AMP/ASCO/CAP (AAC) 2017 Guidleines.
+          properties:
+            primaryCoding:
+              code:
+                enum:
+                  -                # TO DO: Kori/Alex to populate value set here, as approriate
+                  - 
+                  -  
+              system:
+                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+        specifiedBy:
+          description: >-
+            The method that specifies how the oncogenicity classification is ultimately assigned to the variant,
+            based on assessment of evidence.
+          properties:
+            reportedIn:
+               properties:
+                  pmid:
+                    const: 27993330
+                  name:
+                    const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+          required:
+            - reportedIn
+      required:
+        -                          # TO DO: Kori/Alex to specify which, if any, attributes shoudl be required here
+

--- a/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
@@ -29,36 +29,39 @@ $defs:
             may be assessed and reported by the Statement.
         strength:
           description: >-
-            The strength of support that the Therapeutic Response statement is determined to provide
-            for or against the reported therapeutic response association of the assessed variant - based on the
-            AMP/ASCO/CAP (AAC) 2017 Guidleines.  The enumerated value set here is bound to the ‘code’ field in the
-            Coding object nested inside a MappableConcept. Conditional requirement: Strength is evaluated relative
-            to the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', 
-            then this attribute is required.  If it is 'neutral', then this attribute is not allowed.
+            The strength of support that the Statement is determined to provide for or against the Therapeutic Response
+            Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC)
+            2017 Guidelines. Note that the enumerated value set here is bound to the ‘code’ field of the Coding object that
+            is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
+            the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
+            'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
           properties:
             primaryCoding:
               code:
-                enum:
-                  -                 # TO DO: Kori/Alex to populate value set here, as appropriate
+                enum:              # TO DO: Kori/Alex to populate value set here, as appropriate
+                  -                
                   -  
                   -
               system:
                 const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
         classification:
           description: >-
-            The classification of the variant's therapeutic response association, based on the AMP/ASCO/CAP (AAC) 2017 Guidleines.
+            A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
+            the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
+            enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
+            primary coding.
           properties:
             primaryCoding:
               code:
-                enum:
-                  -                # TO DO: Kori/Alex to populate value set here, as approriate
+                enum:              # TO DO: Kori/Alex to populate value set here, as approriate
+                  -                
                   - 
                   -  
               system:
                 const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
         specifiedBy:
           description: >-
-            The method that specifies how the oncogenicity classification is ultimately assigned to the variant,
+            A method that specifies how the therapeutic response classification was ultimately assigned to the variant,
             based on assessment of evidence.
           properties:
             reportedIn:
@@ -69,6 +72,6 @@ $defs:
                     const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
           required:
             - reportedIn
-      required:
-        -                          # TO DO: Kori/Alex to specify which, if any, attributes shoudl be required here
+      required:                   # TO DO: Kori/Alex to specify which, if any, attributes shoudl be required here
+        -                         
 

--- a/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/aac-2017/therapeutic-response-study-statement-profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/aac-2017/therapeutic-response-study-statement-profile-source.yaml"
 title: Variant Therapeutic Response Study Statement Profile (AAC 2017)
 description: >-
   Profile defined to align with terminology and conventions from the Association for Molecular Pathology (AMP),
@@ -19,10 +19,10 @@ $defs:
       is associated with a therapeutic response (positive or negative) - based on interpretation of the study's
       results.
     allOf:
-    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
     - properties:
         proposition:
-          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantTherapeuticResponseProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantTherapeuticResponseProposition"
           description: >-
             A proposition about the therapeutic response associated with a variant, for which the study provides
             evidence. The validity of this proposition, and the level of confidence/evidence supporting it,
@@ -35,42 +35,59 @@ $defs:
             is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
             the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
             'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
-          properties:
-            primaryCoding:
-              code:
-                enum:              # TO DO: Kori/Alex to populate value set here, as appropriate
-                  -
-                  -
-                  -
-              system:
-                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+          oneOf:
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Level A
+                    - Level B
+                    - Level C
+                    - Level D
+                system:
+                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Level E
+                system:
+                  const: CIViC SOP AAC Guidelines, 2019
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
             the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
             enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
             primary coding.
-          properties:
-            primaryCoding:
-              code:
-                enum:              # TO DO: Kori/Alex to populate value set here, as approriate
-                  -
-                  -
-                  -
-              system:
-                const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
+          oneOf:
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Tier I
+                    - Tier II
+                    - Tier III
+                    - Tier IV
+                system:
+                  const: AMP/ASCO/CAP (AAC) Guidelines, 2017
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - Tier I - Sensitivity/Response
+                    - Tier I - Resistance
+                    - Tier I - Adverse Response
+                    - Tier I - Reduced Response
+                    - Tier II - Sensitivity/Response
+                    - Tier II - Resistance
+                    - Tier II - Adverse Response
+                    - Tier II - Reduced Response
+                system:
+                  const: CIViC SOP AAC Guidelines, 2019
         specifiedBy:
           description: >-
             A method that specifies how the therapeutic response classification was ultimately assigned to the variant,
             based on assessment of evidence.
-          properties:
-            reportedIn:
-               properties:
-                  pmid:
-                    const: 27993330
-                  name:
-                    const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
-          required:
-            - reportedIn
-      required:                   # TO DO: Kori/Alex to specify which, if any, attributes shoudl be required here
-        -
+      required:
+        - classification
+        - specifiedBy

--- a/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
@@ -39,8 +39,8 @@ $defs:
             primaryCoding:
               code:
                 enum:              # TO DO: Kori/Alex to populate value set here, as appropriate
-                  -                
-                  -  
+                  -
+                  -
                   -
               system:
                 const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
@@ -54,9 +54,9 @@ $defs:
             primaryCoding:
               code:
                 enum:              # TO DO: Kori/Alex to populate value set here, as approriate
-                  -                
-                  - 
-                  -  
+                  -
+                  -
+                  -
               system:
                 const: AMP/ASCO/CAP (AAC) Guidleines for the Interpretation and Reporting of Sequence Variants in Cancer, 2017
         specifiedBy:
@@ -73,5 +73,4 @@ $defs:
           required:
             - reportedIn
       required:                   # TO DO: Kori/Alex to specify which, if any, attributes shoudl be required here
-        -                         
-
+        -

--- a/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
+++ b/schema/va-spec/aac-2017/therapeutic-response-study-statement-profile-source.yaml
@@ -31,63 +31,37 @@ $defs:
           description: >-
             The strength of support that the Statement is determined to provide for or against the Therapeutic Response
             Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP (AAC)
-            2017 Guidelines. Note that the enumerated value set here is bound to the ‘code’ field of the Coding object that
-            is nested inside a MappableConcept's primary coding. Conditional requirement: Strength is evaluated relative to
-            the direction indicated by the 'direction' attribute. If direction is either 'supports' or 'disputes', the
-            'strength' attribute is required.  If the direction is 'neutral', then the 'strength' attribute is not allowed.
+            2017 Guidelines.
           properties:
             primaryCoding:
               allOf:
                 - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
-                - oneOf:
-                  - properties:
-                        code:
-                          enum:
-                            - Level A
-                            - Level B
-                            - Level C
-                            - Level D
-                        system:
-                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-                  - properties:
-                        code:
-                          enum:
-                            - Level E
-                        system:
-                          const: CIViC SOP AAC Guidelines, 2019
+                - properties:
+                      code:
+                        enum:
+                          - Level A
+                          - Level B
+                          - Level C
+                          - Level D
+                      system:
+                        const: AMP/ASCO/CAP (AAC) Guidelines, 2017
         classification:
           description: >-
             A single term or phrase classifying the subject variant based on the outcome of direction and strength assessments of
-            the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines. Note that the
-            enumerated value set here is bound to the ‘code’ field of the Coding object that is nested inside a MappableConcept's
-            primary coding.
+            the Statement's Proposition - reported here using terms from the AMP/ASCO/CAP (AAC) 2017 Guidelines.
           properties:
             primaryCoding:
               allOf:
                 - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
-                - oneOf:
-                  - properties:
-                        code:
-                          enum:
-                            - Tier I
-                            - Tier II
-                            - Tier III
-                            - Tier IV
-                        system:
-                          const: AMP/ASCO/CAP (AAC) Guidelines, 2017
-                  - properties:
-                        code:
-                          enum:
-                            - Tier I - Sensitivity/Response
-                            - Tier I - Resistance
-                            - Tier I - Adverse Response
-                            - Tier I - Reduced Response
-                            - Tier II - Sensitivity/Response
-                            - Tier II - Resistance
-                            - Tier II - Adverse Response
-                            - Tier II - Reduced Response
-                        system:
-                          const: CIViC SOP AAC Guidelines, 2019
+                - properties:
+                    code:
+                      enum:
+                        - Tier I
+                        - Tier II
+                        - Tier III
+                        - Tier IV
+                    system:
+                      const: AMP/ASCO/CAP (AAC) Guidelines, 2017
         specifiedBy:
           description: >-
             A method that specifies how the therapeutic response classification was ultimately assigned to the variant,

--- a/schema/va-spec/acmg-2015/json/VariantPathogenicityFunctionalImpactEvidenceLine
+++ b/schema/va-spec/acmg-2015/json/VariantPathogenicityFunctionalImpactEvidenceLine
@@ -1,18 +1,18 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/acmg-2015/json/VariantPathogenicityFunctionalImpactEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/acmg-2015/json/VariantPathogenicityFunctionalImpactEvidenceLine",
    "title": "VariantPathogenicityFunctionalImpactEvidenceLine",
    "description": "An Evidence Line that describes how information about the functional impact of a variant on a gene or gene product was interpreted as evidence for or against the variant's pathogenicity.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/EvidenceLine"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/EvidenceLine"
       },
       {
          "properties": {
             "targetProposition": {
                "description": "A Variant Pathogenicity Proposition against which functional impact information was assessed, in determining the strength and direction of support this information provides as evidence.",
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPathogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPathogenicityProposition"
             },
             "strengthOfEvidenceProvided": {
                "description": "The strength of support that an Evidence Line is determined to provide for or against the proposed pathogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by the 'directionOfEvidenceProvided' attribute. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength. Conditional requirement: if directionOfEvidenceProvided is either 'supports' or 'disputes', then this attribute is required. If it is 'none', then this attribute is not allowed.",
@@ -20,6 +20,8 @@
                   "primaryCoding": {
                      "code": {
                         "enum": [
+                           "standalone",
+                           "very strong",
                            "strong",
                            "moderate",
                            "supporting"

--- a/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
+++ b/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
@@ -15,7 +15,7 @@
                "description": "A proposition about the pathogenicity of a varaint, the validity of which is assessed and reported by the Statement. A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the level of confidence/evidence supporting this claim."
             },
             "strength": {
-               "description": "The strength of support that an ACMG 2015 Variant Pathogenicity statement is determined to provide for or against the proposed pathogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by the 'direction' attribute. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength. Conditional requirement: if direction is either 'supports' or 'disputes', then this attribute is required.  If it is 'neutral', then this attribute is not allowed.",
+               "description": "The strength of support that an ACMG 2015 Variant Pathogenicity statement is determined to provide for or against the proposed pathogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by the 'direction' attribute. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength.",
                "properties": {
                   "primaryCoding": {
                      "code": {

--- a/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
+++ b/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
@@ -35,44 +35,51 @@
             },
             "classification": {
                "description": "The classification of the variant's pathogenicity, based on the ACMG 2015 guidelines. These classifications should coincide with the direction and strength values as follows: 'pathogenic' with supports-strong, 'likely pathogenic' with supports-moderate, 'benign' with disputes-strong, 'likely benign' with disputes-moderate 'uncertain significance' can be one of three possibilities... supports-weak, disputes-weak or neutral for uncertain significance (favoring pathogenic), uncertain significance (favoring benign) or uncertain significance (favoring neither pathogenic nor benign). The 'low penetrance' and 'risk allele' versions of pathogenicity classifications would be applied based on whether the variant proposition was defined to have a 'penetrance' of 'low' or 'risk' respectively.",
-               "oneOf": [
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "pathogenic",
-                                 "likely pathogenic",
-                                 "benign",
-                                 "likely benign",
-                                 "uncertain significance"
-                              ]
-                           },
-                           "system": {
-                              "const": "ACMG Guidelines, 2015"
-                           }
+               "properties": {
+                  "primaryCoding": {
+                     "allOf": [
+                        {
+                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                        },
+                        {
+                           "oneOf": [
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "pathogenic",
+                                          "likely pathogenic",
+                                          "benign",
+                                          "likely benign",
+                                          "uncertain significance"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "ACMG Guidelines, 2015"
+                                    }
+                                 }
+                              },
+                              {
+                                 "properties": {
+                                    "code": {
+                                       "enum": [
+                                          "pathogenic, low penetrance",
+                                          "likely pathogenic, low penetrance",
+                                          "established risk allele",
+                                          "likely risk allele",
+                                          "uncertain risk allele"
+                                       ]
+                                    },
+                                    "system": {
+                                       "const": "ClinGen Low Penetrance and Risk Allele Recommendations, 2024"
+                                    }
+                                 }
+                              }
+                           ]
                         }
-                     }
-                  },
-                  {
-                     "properties": {
-                        "primaryCoding": {
-                           "code": {
-                              "enum": [
-                                 "pathogenic, low penetrance",
-                                 "likely pathogenic, low penetrance",
-                                 "established risk allele",
-                                 "likely risk allele",
-                                 "uncertain risk allele"
-                              ]
-                           },
-                           "system": {
-                              "const": "ClinGen Low Penetrance and Risk Allele Recommendations, 2024"
-                           }
-                        }
-                     }
+                     ]
                   }
-               ]
+               }
             },
             "specifiedBy": {
                "description": "The method that specifies how the pathogenicity classification is ultimately assigned to the variant, based on assessment of evidence."

--- a/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
+++ b/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
@@ -1,17 +1,17 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/acmg-2015/json/VariantPathogenicityStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/acmg-2015/json/VariantPathogenicityStatement",
    "title": "VariantPathogenicityStatement",
    "description": "A Statement describing the role of a variant in causing an inherited condition.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPathogenicityProposition",
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPathogenicityProposition",
                "description": "A proposition about the pathogenicity of a varaint, the validity of which is assessed and reported by the Statement. A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the level of confidence/evidence supporting this claim."
             },
             "strength": {
@@ -20,46 +20,62 @@
                   "primaryCoding": {
                      "code": {
                         "enum": [
-                           "strong",
-                           "moderate",
-                           "weak"
+                           "definitive",
+                           "likely"
                         ]
                      },
                      "system": {
                         "const": "ACMG Guidelines, 2015"
                      }
                   }
-               }
+               },
+               "required": [
+                  "primaryCoding"
+               ]
             },
             "classification": {
                "description": "The classification of the variant's pathogenicity, based on the ACMG 2015 guidelines. These classifications should coincide with the direction and strength values as follows: 'pathogenic' with supports-strong, 'likely pathogenic' with supports-moderate, 'benign' with disputes-strong, 'likely benign' with disputes-moderate 'uncertain significance' can be one of three possibilities... supports-weak, disputes-weak or neutral for uncertain significance (favoring pathogenic), uncertain significance (favoring benign) or uncertain significance (favoring neither pathogenic nor benign). The 'low penetrance' and 'risk allele' versions of pathogenicity classifications would be applied based on whether the variant proposition was defined to have a 'penetrance' of 'low' or 'risk' respectively.",
-               "properties": {
-                  "primaryCoding": {
-                     "code": {
-                        "enum": [
-                           "pathogenic",
-                           "pathogenic, low penetrance",
-                           "established risk allele",
-                           "likely pathogenic",
-                           "likely pathogenic, low penetrance",
-                           "likely risk allele",
-                           "uncertain significance",
-                           "uncertain risk allele",
-                           "likely benign",
-                           "benign"
-                        ]
-                     },
-                     "system": {
-                        "const": "ACMG Guidelines, 2015"
+               "oneOf": [
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "pathogenic",
+                                 "likely pathogenic",
+                                 "benign",
+                                 "likely benign",
+                                 "uncertain significance"
+                              ]
+                           },
+                           "system": {
+                              "const": "ACMG Guidelines, 2015"
+                           }
+                        }
+                     }
+                  },
+                  {
+                     "properties": {
+                        "primaryCoding": {
+                           "code": {
+                              "enum": [
+                                 "pathogenic, low penetrance",
+                                 "likely pathogenic, low penetrance",
+                                 "established risk allele",
+                                 "likely risk allele",
+                                 "uncertain risk allele"
+                              ]
+                           },
+                           "system": {
+                              "const": "ClinGen Low Penetrance and Risk Allele Recommendations, 2024"
+                           }
+                        }
                      }
                   }
-               }
+               ]
             },
             "specifiedBy": {
-               "description": "The method that specifies how the pathogenicity classification is ultimately assigned to the variant, based on assessment of evidence.",
-               "required": [
-                  "reportedIn"
-               ]
+               "description": "The method that specifies how the pathogenicity classification is ultimately assigned to the variant, based on assessment of evidence."
             }
          },
          "required": [

--- a/schema/va-spec/acmg-2015/pathogenicity-functional-impact-evidence-line-profile-source.yaml
+++ b/schema/va-spec/acmg-2015/pathogenicity-functional-impact-evidence-line-profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/acmg-2015/pathogenicity-functional-impact--profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/acmg-2015/pathogenicity-functional-impact--profile-source.yaml"
 title: Variant Pathogenicity Functional Impact Evidence Line Profile (ACMG 2015)
 description: >-
   Profile defined to align with terminology and conventions from the American College of Medical Genetics
@@ -17,13 +17,13 @@ $defs:
       An Evidence Line that describes how information about the functional impact of a variant on a gene or
       gene product was interpreted as evidence for or against the variant's pathogenicity.
     allOf:
-    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/EvidenceLine"
+    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/EvidenceLine"
     - properties:
         targetProposition:
           description: >-
             A Variant Pathogenicity Proposition against which functional impact information was assessed,
             in determining the strength and direction of support this information provides as evidence.
-          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPathogenicityProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPathogenicityProposition"
         strengthOfEvidenceProvided:
           description: >-
             The strength of support that an Evidence Line is determined to provide for or against the proposed
@@ -36,6 +36,8 @@ $defs:
             primaryCoding:
               code:
                 enum:
+                  - stand alone
+                  - very strong
                   - strong
                   - moderate
                   - supporting
@@ -45,16 +47,6 @@ $defs:
           description: >-
             The guidelines that were followed to interpret variant functional impact information
             as evidence for or against the assessed variant's pathogenicity.
-        # removing the strict requirement for 'reportedIn' to allow for other guidelines
-        # which may be specializations of ACMG Guidelines, 2015 (e.g. VCEP guidelines)
-        # we should revisit this decision before finalizing the constraint around `specifiedBy`
-        #   properties:
-        #     reportedIn:
-        #        properties:
-        #           pmid:
-        #             const: 25741868
-        #           name:
-        #             const: ACMG Guidelines, 2015
           required:
             - reportedIn
         evidenceOutcome:

--- a/schema/va-spec/acmg-2015/pathogenicity-functional-impact-evidence-line-profile-source.yaml
+++ b/schema/va-spec/acmg-2015/pathogenicity-functional-impact-evidence-line-profile-source.yaml
@@ -36,7 +36,7 @@ $defs:
             primaryCoding:
               code:
                 enum:
-                  - stand alone
+                  - standalone
                   - very strong
                   - strong
                   - moderate

--- a/schema/va-spec/acmg-2015/pathogenicity-statement-profile-source.yaml
+++ b/schema/va-spec/acmg-2015/pathogenicity-statement-profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/acmg-2015/pathogenicity-statement-profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/acmg-2015/pathogenicity-statement-profile-source.yaml"
 title: Variant Pathogenicity Statement Profile (ACMG 2015)
 description: >-
   Profile defined to align with terminology and conventions from the American College of Medical Genetics
@@ -17,10 +17,10 @@ $defs:
     description: >-
       A Statement describing the role of a variant in causing an inherited condition.
     allOf:
-    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
     - properties:
         proposition:
-          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPathogenicityProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPathogenicityProposition"
           description: >-
             A proposition about the pathogenicity of a varaint, the validity of which is assessed and reported by the Statement.
             A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the
@@ -41,6 +41,7 @@ $defs:
                   - likely
               system:
                 const: ACMG Guidelines, 2015
+          required: [primaryCoding]
         classification:
           description: >-
             The classification of the variant's pathogenicity, based on the ACMG 2015 guidelines.
@@ -53,38 +54,33 @@ $defs:
             The 'low penetrance' and 'risk allele' versions of pathogenicity classifications would be
             applied based on whether the variant proposition was defined to have a 'penetrance' of
             'low' or 'risk' respectively.
-          properties:
-            primaryCoding:
-              code:
-                enum:
-                  - pathogenic
-                  - pathogenic, low penetrance
-                  - established risk allele
-                  - likely pathogenic
-                  - likely pathogenic, low penetrance
-                  - likely risk allele
-                  - uncertain significance
-                  - uncertain risk allele
-                  - likely benign
-                  - benign
-              system:
-                const: ACMG Guidelines, 2015
+          oneOf:
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - pathogenic
+                    - likely pathogenic
+                    - benign
+                    - likely benign
+                    - uncertain significance
+                system:
+                  const: ACMG Guidelines, 2015
+          - properties:
+              primaryCoding:
+                code:
+                  enum:
+                    - pathogenic, low penetrance
+                    - likely pathogenic, low penetrance
+                    - established risk allele
+                    - likely risk allele
+                    - uncertain risk allele
+                system:
+                  const: ClinGen Low Penetrance and Risk Allele Recommendations, 2024
         specifiedBy:
           description: >-
             The method that specifies how the pathogenicity classification is ultimately assigned to the variant,
             based on assessment of evidence.
-        # removing the strict requirement for 'reportedIn' to allow for other guidelines
-        # which may be specializations of ACMG Guidelines, 2015 (e.g. VCEP guidelines)
-        # we should revisit this decision before finalizing the constraint around `specifiedBy`
-        #   properties:
-        #     reportedIn:
-        #        properties:
-        #           pmid:
-        #             const: 25741868
-        #           name:
-        #             const: ACMG Guidelines, 2015
-          required:
-            - reportedIn
       required:
         - classification
         - specifiedBy

--- a/schema/va-spec/acmg-2015/pathogenicity-statement-profile-source.yaml
+++ b/schema/va-spec/acmg-2015/pathogenicity-statement-profile-source.yaml
@@ -37,9 +37,8 @@ $defs:
             primaryCoding:
               code:
                 enum:
-                  - strong
-                  - moderate
-                  - weak
+                  - definitive
+                  - likely
               system:
                 const: ACMG Guidelines, 2015
         classification:

--- a/schema/va-spec/acmg-2015/pathogenicity-statement-profile-source.yaml
+++ b/schema/va-spec/acmg-2015/pathogenicity-statement-profile-source.yaml
@@ -54,29 +54,31 @@ $defs:
             The 'low penetrance' and 'risk allele' versions of pathogenicity classifications would be
             applied based on whether the variant proposition was defined to have a 'penetrance' of
             'low' or 'risk' respectively.
-          oneOf:
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - pathogenic
-                    - likely pathogenic
-                    - benign
-                    - likely benign
-                    - uncertain significance
-                system:
-                  const: ACMG Guidelines, 2015
-          - properties:
-              primaryCoding:
-                code:
-                  enum:
-                    - pathogenic, low penetrance
-                    - likely pathogenic, low penetrance
-                    - established risk allele
-                    - likely risk allele
-                    - uncertain risk allele
-                system:
-                  const: ClinGen Low Penetrance and Risk Allele Recommendations, 2024
+          properties:
+            primaryCoding:
+              allOf:
+                - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                - oneOf:
+                  - properties:
+                      code:
+                        enum:
+                          - pathogenic
+                          - likely pathogenic
+                          - benign
+                          - likely benign
+                          - uncertain significance
+                      system:
+                        const: ACMG Guidelines, 2015
+                  - properties:
+                      code:
+                        enum:
+                          - pathogenic, low penetrance
+                          - likely pathogenic, low penetrance
+                          - established risk allele
+                          - likely risk allele
+                          - uncertain risk allele
+                      system:
+                        const: ClinGen Low Penetrance and Risk Allele Recommendations, 2024
         specifiedBy:
           description: >-
             The method that specifies how the pathogenicity classification is ultimately assigned to the variant,

--- a/schema/va-spec/acmg-2015/pathogenicity-statement-profile-source.yaml
+++ b/schema/va-spec/acmg-2015/pathogenicity-statement-profile-source.yaml
@@ -31,8 +31,6 @@ $defs:
             for or against the proposed pathogenicity of the assessed variant. Strength is evaluated relative
             to the direction indicated by the 'direction' attribute. The indicated enumeration constrains the nested
             MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength.
-            Conditional requirement: if direction is either 'supports' or 'disputes', then this
-            attribute is required.  If it is 'neutral', then this attribute is not allowed.
           properties:
             primaryCoding:
               code:

--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/domain-entities-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/domain-entities-source.yaml"
 title: VA Spec Shared Domain Entity Data Structures
 strict: true
 

--- a/schema/va-spec/base/json/Agent
+++ b/schema/va-spec/base/json/Agent
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Agent",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Agent",
    "title": "Agent",
    "type": "object",
    "maturity": "trial use",

--- a/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
+++ b/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
@@ -104,7 +104,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
             }
          ],
          "description": "The Allele for which frequency results are reported.",

--- a/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
+++ b/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/CohortAlleleFrequencyStudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/CohortAlleleFrequencyStudyResult",
    "title": "CohortAlleleFrequencyStudyResult",
    "maturity": "trial use",
    "type": "object",
@@ -39,7 +39,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -63,7 +63,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Document"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
@@ -94,7 +94,7 @@
          "default": "CohortAlleleFrequencyStudyResult"
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/DataSet",
          "description": "The dataset from which the CohortAlleleFrequencyStudyResult was reported.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance."
       },
@@ -123,7 +123,7 @@
          "description": "The frequency of the focusAllele in the cohort."
       },
       "cohort": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/StudyGroup",
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/StudyGroup",
          "description": "The cohort from which the frequency was derived."
       },
       "subCohortFrequency": {
@@ -131,7 +131,7 @@
          "ordered": false,
          "description": "A list of CohortAlleleFrequency objects describing subcohorts of the cohort currently being described. Subcohorts can be further subdivided into more subcohorts. This enables, for example, the description of different ancestry groups and sexes among those ancestry groups.",
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/CohortAlleleFrequencyStudyResult"
+            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/CohortAlleleFrequencyStudyResult"
          }
       }
    },

--- a/schema/va-spec/base/json/Condition
+++ b/schema/va-spec/base/json/Condition
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Condition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Condition",
    "title": "Condition",
    "maturity": "trial use",
    "description": "A single condition (disease, phenotype, or trait), or a set of conditions (ConditionSet).",
    "$comment": "At present, individual conditions are represented using a MappableConcept that captures a code or name for the condition, along with optional mappings and metadata about the code system. Groups of conditions are represented using the ConditionSet class, which are collections of 2 or more conditions, each represented as a MappableConcept. By convention, cases where no condition is given by the data provider SHOULD be specified using a MappableConcept with a conceptType = \"Absent\". Additionally, either the 'name' or 'primaryCoding' attribute of a MappableConcept must be populated.  The name or code may simple reiterate the conceptType (e.g. 'condition absent'), or report a more specific nature or reason for the absence of a condition (e.g. 'Data Missing in Source', 'Condition Unknown', 'All Mendelian Diseases').",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/ConditionSet"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/ConditionSet"
       },
       {
          "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"

--- a/schema/va-spec/base/json/ConditionSet
+++ b/schema/va-spec/base/json/ConditionSet
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/ConditionSet",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/ConditionSet",
    "title": "ConditionSet",
    "type": "object",
    "maturity": "trial use",

--- a/schema/va-spec/base/json/Contribution
+++ b/schema/va-spec/base/json/Contribution
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Contribution",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Contribution",
    "title": "Contribution",
    "type": "object",
    "maturity": "trial use",
@@ -44,7 +44,7 @@
          "default": "Contribution"
       },
       "contributor": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Agent",
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Agent",
          "description": "The agent that made the contribution."
       },
       "activityType": {

--- a/schema/va-spec/base/json/DataSet
+++ b/schema/va-spec/base/json/DataSet
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/DataSet",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/DataSet",
    "title": "DataSet",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
       "reportedIn": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Document"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Document"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"

--- a/schema/va-spec/base/json/Document
+++ b/schema/va-spec/base/json/Document
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Document",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Document",
    "title": "Document",
    "type": "object",
    "maturity": "trial use",

--- a/schema/va-spec/base/json/EvidenceLine
+++ b/schema/va-spec/base/json/EvidenceLine
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/EvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/EvidenceLine",
    "title": "EvidenceLine",
    "type": "object",
    "maturity": "trial use",
@@ -40,7 +40,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -64,7 +64,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Document"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
@@ -84,22 +84,22 @@
          "description": "The possible fact against which evidence items contained in an Evidence Line were collectively evaluated, in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against a target proposition that the variant is pathogenic for a specific disease.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/ExperimentalVariantFunctionalImpactProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/ExperimentalVariantFunctionalImpactProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantDiagnosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantDiagnosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantOncogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantOncogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPathogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPathogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPrognosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPrognosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantTherapeuticResponseProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantTherapeuticResponseProposition"
             }
          ]
       },
@@ -109,13 +109,13 @@
          "items": {
             "anyOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/StudyResult"
+                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/StudyResult"
                },
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
                },
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/EvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/EvidenceLine"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/ExperimentalVariantFunctionalImpactProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/ExperimentalVariantFunctionalImpactProposition",
    "title": "ExperimentalVariantFunctionalImpactProposition",
    "maturity": "trial use",
    "type": "object",
@@ -83,7 +83,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Document"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Document"
             },
             {
                "type": "object",

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.1/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.2/json/CategoricalVariant"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
@@ -87,7 +87,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
             }
          ],
          "description": "The genetic variant for which a functional impact score is generated.",

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/ExperimentalVariantFunctionalImpactStudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/ExperimentalVariantFunctionalImpactStudyResult",
    "title": "ExperimentalVariantFunctionalImpactStudyResult",
    "maturity": "trial use",
    "type": "object",
@@ -40,7 +40,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -51,7 +51,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Document"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
@@ -100,7 +100,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
@@ -110,7 +110,7 @@
          "$comment": "Examples: a specific experimental protocol or data analysis specification that describes how data were generated; an evidence interpretation guideline that describes steps taken to interpret data in making a variant pathogenicity classification; a method for using electron microscopy to image cell membrane proteins. Note that this attribute captures a specific *instance* of a specification or method (e.g. the specific electron microscopy method described in https://doi.org/10.1002/cpz1.1045) - as opposed to reporting a *type* of method applied (e.g. 'Transmission Electron Microscopy')."
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/DataSet",
          "description": "The full data set that provided the reported the functional impact score.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance."
       }

--- a/schema/va-spec/base/json/Method
+++ b/schema/va-spec/base/json/Method
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Method",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Method",
    "title": "Method",
    "type": "object",
    "maturity": "trial use",
@@ -52,7 +52,7 @@
       "reportedIn": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Document"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Document"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"

--- a/schema/va-spec/base/json/Statement
+++ b/schema/va-spec/base/json/Statement
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement",
    "title": "Statement",
    "type": "object",
    "maturity": "trial use",
@@ -40,7 +40,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -64,7 +64,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Document"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
@@ -85,22 +85,22 @@
          "$comment": "Statements put forth a Proposition that expresses some possible fact about the world, and may provide an assessment of this proposition\u2019s validity (i.e. how likely it is to be true or false based on evaluated evidence). The semantics of the Proposition are explicitly captured using subject, predicate, object, and optional qualifier attributes (SPOQ). An assessment of the Proposition\u2019s validity can optionally be captured using the Statement's direction, strength, and/or score attributes (DS).",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/ExperimentalVariantFunctionalImpactProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/ExperimentalVariantFunctionalImpactProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantDiagnosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantDiagnosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantOncogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantOncogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPathogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPathogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPrognosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPrognosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantTherapeuticResponseProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantTherapeuticResponseProposition"
             }
          ]
       },
@@ -136,7 +136,7 @@
          "items": {
             "anyOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/EvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/EvidenceLine"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"

--- a/schema/va-spec/base/json/StudyGroup
+++ b/schema/va-spec/base/json/StudyGroup
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/StudyGroup",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/StudyGroup",
    "title": "StudyGroup",
    "type": "object",
    "maturity": "trial use",

--- a/schema/va-spec/base/json/StudyResult
+++ b/schema/va-spec/base/json/StudyResult
@@ -1,16 +1,16 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/StudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/StudyResult",
    "title": "StudyResult",
    "maturity": "trial use",
    "description": "A collection of data items from a single study that pertain to a particular subject or experimental unit in the study, along with optional provenance information describing how these data items were generated.",
    "$comment": "Note that a 'dataItem' attribute, which would hold an array of data selected for inclusion in the StudyResult, is not included in this version of the StudyResult class. Profiles that extend this core class can define data type specific attributes to capture such information (e.g.'focusAlleleCount', 'focusAlleleFrequency', and 'locuslAlleleCount' attributes in a CohortAlleleFrequencyStudyResult profile). But technical limitations in our current profiling framework tooling forced us to omit a core 'dataItems attribute that these specialized attributes would conceptually extend.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/CohortAlleleFrequencyStudyResult"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/CohortAlleleFrequencyStudyResult"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/ExperimentalVariantFunctionalImpactStudyResult"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/ExperimentalVariantFunctionalImpactStudyResult"
       }
    ]
 }

--- a/schema/va-spec/base/json/SubjectVariantProposition
+++ b/schema/va-spec/base/json/SubjectVariantProposition
@@ -1,27 +1,27 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/SubjectVariantProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/SubjectVariantProposition",
    "title": "SubjectVariantProposition",
    "maturity": "trial use",
    "description": "A Proposition that has a variant as the subject.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/ExperimentalVariantFunctionalImpactProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/ExperimentalVariantFunctionalImpactProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantDiagnosticProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantDiagnosticProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantOncogenicityProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantOncogenicityProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPathogenicityProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPathogenicityProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPrognosticProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPrognosticProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantTherapeuticResponseProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantTherapeuticResponseProposition"
       }
    ]
 }

--- a/schema/va-spec/base/json/Therapeutic
+++ b/schema/va-spec/base/json/Therapeutic
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Therapeutic",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Therapeutic",
    "title": "Therapeutic",
    "maturity": "trial use",
    "description": "An individual therapy (drug, procedure, behavioral intervention, etc.), or group of therapies (TherapyGroup).",
    "$comment": "At present, individual therapies are represented using a MappableConcept that captures a code or name for the therapy, along with optional mappings and metadata about the code system. Groups of therapies are represented using the TherapyGroup class, which are collections of 2 or more therapies, each represented as a MappableConcept.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/TherapyGroup"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/TherapyGroup"
       },
       {
          "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"

--- a/schema/va-spec/base/json/TherapyGroup
+++ b/schema/va-spec/base/json/TherapyGroup
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/TherapyGroup",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/TherapyGroup",
    "title": "TherapyGroup",
    "type": "object",
    "maturity": "trial use",

--- a/schema/va-spec/base/json/VariantDiagnosticProposition
+++ b/schema/va-spec/base/json/VariantDiagnosticProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantDiagnosticProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantDiagnosticProposition",
    "title": "VariantDiagnosticProposition",
    "type": "object",
    "maturity": "trial use",
@@ -96,7 +96,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Condition"
             }
          ],
          "description": "The disease that is evaluated for diagnosis.",

--- a/schema/va-spec/base/json/VariantDiagnosticProposition
+++ b/schema/va-spec/base/json/VariantDiagnosticProposition
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.1/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.2/json/CategoricalVariant"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",

--- a/schema/va-spec/base/json/VariantOncogenicityProposition
+++ b/schema/va-spec/base/json/VariantOncogenicityProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantOncogenicityProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantOncogenicityProposition",
    "title": "VariantOncogenicityProposition",
    "maturity": "trial use",
    "type": "object",
@@ -93,7 +93,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Condition"
             }
          ],
          "description": "The tumor type for which the variant impact is evaluated.",

--- a/schema/va-spec/base/json/VariantOncogenicityProposition
+++ b/schema/va-spec/base/json/VariantOncogenicityProposition
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.1/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.2/json/CategoricalVariant"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",

--- a/schema/va-spec/base/json/VariantPathogenicityProposition
+++ b/schema/va-spec/base/json/VariantPathogenicityProposition
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.1/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.2/json/CategoricalVariant"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",

--- a/schema/va-spec/base/json/VariantPathogenicityProposition
+++ b/schema/va-spec/base/json/VariantPathogenicityProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPathogenicityProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPathogenicityProposition",
    "title": "VariantPathogenicityProposition",
    "maturity": "trial use",
    "type": "object",
@@ -93,7 +93,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Condition"
             }
          ],
          "description": "The Condition for which the variant impact is stated.",

--- a/schema/va-spec/base/json/VariantPrognosticProposition
+++ b/schema/va-spec/base/json/VariantPrognosticProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantPrognosticProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantPrognosticProposition",
    "title": "VariantPrognosticProposition",
    "type": "object",
    "maturity": "trial use",
@@ -96,7 +96,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Condition"
             }
          ],
          "description": "The disease that is evaluated for outcome.",

--- a/schema/va-spec/base/json/VariantPrognosticProposition
+++ b/schema/va-spec/base/json/VariantPrognosticProposition
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.1/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.2/json/CategoricalVariant"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",

--- a/schema/va-spec/base/json/VariantTherapeuticResponseProposition
+++ b/schema/va-spec/base/json/VariantTherapeuticResponseProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantTherapeuticResponseProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantTherapeuticResponseProposition",
    "title": "VariantTherapeuticResponseProposition",
    "maturity": "trial use",
    "type": "object",
@@ -96,7 +96,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Therapeutic"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Therapeutic"
             }
          ],
          "description": "A drug administration or other therapeutic procedure that the neoplasm is intended to respond to.",
@@ -108,7 +108,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Condition"
             }
          ],
          "description": "Reports the disease context in which the variant's association with therapeutic sensitivity or resistance is evaluated. Note that this is a required qualifier in therapeutic response propositions."

--- a/schema/va-spec/base/json/VariantTherapeuticResponseProposition
+++ b/schema/va-spec/base/json/VariantTherapeuticResponseProposition
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.1/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.2/json/CategoricalVariant"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.0/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",

--- a/schema/va-spec/base/va-core-source.yaml
+++ b/schema/va-spec/base/va-core-source.yaml
@@ -726,7 +726,7 @@ $defs:
           membership in the group.
         $comment: We should evaluate this for use with boolean operators before going normative
 
-  # proposition concrete profiles section
+  # proposition profiles section
   ClinicalVariantProposition:
     inherits: SubjectVariantProposition
     maturity: trial use

--- a/schema/va-spec/base/va-core-source.yaml
+++ b/schema/va-spec/base/va-core-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/va-spec-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/va-spec-source.yaml"
 title: VA Specification Core classes
 strict: true
 
@@ -11,8 +11,8 @@ imports:
 
 namespaces:
   gks.core: /ga4gh/schema/gks-core/1.0.0/json/
-  vrs: /ga4gh/schema/vrs/2.0.0/json/
-  cat-vrs: /ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.1/json/
+  vrs: /ga4gh/schema/vrs/2.0.1/json/
+  cat-vrs: /ga4gh/schema/cat-vrs/1.0.0-ballot.2025-03.2/json/
 
 $defs:
   # abstract core classes section -- InformationEntity, Activity, StudyResult, Proposition

--- a/schema/va-spec/ccv-2022/json/VariantOncogenicityFunctionalImpactEvidenceLine
+++ b/schema/va-spec/ccv-2022/json/VariantOncogenicityFunctionalImpactEvidenceLine
@@ -15,7 +15,7 @@
                "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantOncogenicityProposition"
             },
             "strengthOfEvidenceProvided": {
-               "description": "The strength of support that an Evidence Line is determined to provide for or against the proposed pathogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by the 'directionOfEvidenceProvided' attribute. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength. Conditional requirement: if directionOfEvidenceProvided is either 'supports' or 'disputes', then this attribute is required. If it is 'none', then this attribute is not allowed.",
+               "description": "The strength of support that an Evidence Line is determined to provide for or against the proposed pathogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by the 'directionOfEvidenceProvided' attribute. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength.",
                "properties": {
                   "primaryCoding": {
                      "code": {
@@ -34,7 +34,7 @@
                }
             },
             "specifiedBy": {
-               "description": "The Clingen/CGC/VICC-2022 criterion that was applied to interpret variant functional impact information as evidence for or against the assessed variant's oncogenicity."
+               "description": "The Clingen/CGC/VICC 2022 criterion that was applied to interpret variant functional impact information as evidence for or against the assessed variant's oncogenicity."
             },
             "evidenceOutcome": {
                "description": "The evidence outcome is a summary of the 'directionOfEvidenceProvided' and 'strengthOfEvidenceProvided' values, along with the specific criterion code used in these assessments. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute to capture evidence outcomes. Note that if 'directionOfEvidenceProvided' is 'none', then the evidence outcome is 'not met' for the relevant criterion (e.g. 'OS2_not_met'). If 'directionOfEvidenceProvided' is 'supports' or 'disputes', then the outcome is 'met' for the relevant criterion, along with the strength of evidence provided. (e.g. 'OS2_moderate').",

--- a/schema/va-spec/ccv-2022/json/VariantOncogenicityFunctionalImpactEvidenceLine
+++ b/schema/va-spec/ccv-2022/json/VariantOncogenicityFunctionalImpactEvidenceLine
@@ -1,18 +1,18 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/ccv-2022/json/VariantOncogenicityFunctionalImpactEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/ccv-2022/json/VariantOncogenicityFunctionalImpactEvidenceLine",
    "title": "VariantOncogenicityFunctionalImpactEvidenceLine",
    "description": "An Evidence Line that describes how information about the functional impact of a variant on a gene or gene product was interpreted as evidence for or against the variant's oncogenicity.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/EvidenceLine"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/EvidenceLine"
       },
       {
          "properties": {
             "targetProposition": {
                "description": "A Variant Oncoogenicity Proposition against which functional impact information was assessed, in determining the strength and direction of support this information provides as evidence.",
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantOncogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantOncogenicityProposition"
             },
             "strengthOfEvidenceProvided": {
                "description": "The strength of support that an Evidence Line is determined to provide for or against the proposed pathogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by the 'directionOfEvidenceProvided' attribute. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength. Conditional requirement: if directionOfEvidenceProvided is either 'supports' or 'disputes', then this attribute is required. If it is 'none', then this attribute is not allowed.",
@@ -20,6 +20,8 @@
                   "primaryCoding": {
                      "code": {
                         "enum": [
+                           "standalone",
+                           "very strong",
                            "strong",
                            "moderate",
                            "supporting"
@@ -32,22 +34,7 @@
                }
             },
             "specifiedBy": {
-               "description": "The Clingen/CGC/VICC-2022 criterion that was applied to interpret variant functional impact information as evidence for or against the assessed variant's oncogenicity.",
-               "properties": {
-                  "reportedIn": {
-                     "properties": {
-                        "pmid": {
-                           "const": 35101336
-                        },
-                        "name": {
-                           "const": "ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022"
-                        }
-                     }
-                  }
-               },
-               "required": [
-                  "reportedIn"
-               ]
+               "description": "The Clingen/CGC/VICC-2022 criterion that was applied to interpret variant functional impact information as evidence for or against the assessed variant's oncogenicity."
             },
             "evidenceOutcome": {
                "description": "The evidence outcome is a summary of the 'directionOfEvidenceProvided' and 'strengthOfEvidenceProvided' values, along with the specific criterion code used in these assessments. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute to capture evidence outcomes. Note that if 'directionOfEvidenceProvided' is 'none', then the evidence outcome is 'not met' for the relevant criterion (e.g. 'OS2_not_met'). If 'directionOfEvidenceProvided' is 'supports' or 'disputes', then the outcome is 'met' for the relevant criterion, along with the strength of evidence provided. (e.g. 'OS2_moderate').",

--- a/schema/va-spec/ccv-2022/json/VariantOncogenicityStudyStatement
+++ b/schema/va-spec/ccv-2022/json/VariantOncogenicityStudyStatement
@@ -15,7 +15,7 @@
                "description": "A proposition about the oncogenicity of a varaint, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
-               "description": "The strength of support that an CCV 2022 Oncogenicity statement is determined to provide for or against the proposed oncogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by the 'direction' attribute. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength. Conditional requirement: if direction is either 'supports' or 'disputes', then this attribute is required.  If it is 'neutral', then this attribute is not allowed.",
+               "description": "The strength of support that an CCV 2022 Oncogenicity statement is determined to provide for or against the proposed oncogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by the 'direction' attribute. The indicated enumeration constrains the nested MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength.",
                "properties": {
                   "primaryCoding": {
                      "code": {
@@ -31,7 +31,6 @@
                }
             },
             "classification": {
-               "description": "The classification of the variant's oncogenicity, based on the CCV 2022 guidelines. These classifications should coincide with the direction and strength values as follows: 'oncogenic' with supports-strong, 'likely oncogenic' with supports-moderate, 'benign' with disputes-strong, 'likely benign' with disputes-moderate 'uncertain significance' can be one of three possibilities... supports-weak, disputes-weak or neutral for uncertain significance (favoring pathogenic), uncertain significance (favoring benign) or uncertain significance (favoring neither pathogenic nor benign).",
                "properties": {
                   "primaryCoding": {
                      "code": {

--- a/schema/va-spec/ccv-2022/json/VariantOncogenicityStudyStatement
+++ b/schema/va-spec/ccv-2022/json/VariantOncogenicityStudyStatement
@@ -1,17 +1,17 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/ccv-2022/json/VariantOncogenicityStudyStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/ccv-2022/json/VariantOncogenicityStudyStatement",
    "title": "VariantOncogenicityStudyStatement",
    "description": "A statement reporting a conclusion from a single study about whether a variant is associated with oncogenicity (positive or negative) - based on interpretation of the study's results.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantOncogenicityProposition",
+               "$ref": "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantOncogenicityProposition",
                "description": "A proposition about the oncogenicity of a varaint, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
@@ -20,9 +20,8 @@
                   "primaryCoding": {
                      "code": {
                         "enum": [
-                           "strong",
-                           "moderate",
-                           "weak"
+                           "definitive",
+                           "likely"
                         ]
                      },
                      "system": {
@@ -51,22 +50,7 @@
                }
             },
             "specifiedBy": {
-               "description": "The method that specifies how the oncogenicity classification is ultimately assigned to the variant, based on assessment of evidence.",
-               "properties": {
-                  "reportedIn": {
-                     "properties": {
-                        "pmid": {
-                           "const": 35101336
-                        },
-                        "name": {
-                           "const": "ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022"
-                        }
-                     }
-                  }
-               },
-               "required": [
-                  "reportedIn"
-               ]
+               "description": "The method that specifies how the oncogenicity classification is ultimately assigned to the variant, based on assessment of evidence."
             }
          },
          "required": [

--- a/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
+++ b/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
@@ -31,8 +31,6 @@ $defs:
             pathogenicity of the assessed variant. Strength is evaluated relative to the direction indicated by
             the 'directionOfEvidenceProvided' attribute. The indicated enumeration constrains the nested
             MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength.
-            Conditional requirement: if directionOfEvidenceProvided is either 'supports' or 'disputes', then this
-            attribute is required. If it is 'none', then this attribute is not allowed.
           properties:
             primaryCoding:
               code:
@@ -46,7 +44,7 @@ $defs:
                 const: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
         specifiedBy:
           description: >-
-            The Clingen/CGC/VICC-2022 criterion that was applied to interpret variant functional impact information
+            The Clingen/CGC/VICC 2022 criterion that was applied to interpret variant functional impact information
             as evidence for or against the assessed variant's oncogenicity.
         evidenceOutcome:
           description: >-

--- a/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
+++ b/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/ccv-2022/oncogenicity-functional-impact--profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/ccv-2022/oncogenicity-functional-impact--profile-source.yaml"
 title: Variant Oncogenicity Functional Impact Evidence Line Profile (CCV 2022)
 description: >-
   Profile defined to align with terminology and conventions from the Clinical Genome Resource (ClinGen),
@@ -18,13 +18,13 @@ $defs:
       An Evidence Line that describes how information about the functional impact of a variant on a gene or
       gene product was interpreted as evidence for or against the variant's oncogenicity.
     allOf:
-    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/EvidenceLine"
+    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/EvidenceLine"
     - properties:
         targetProposition:
           description: >-
             A Variant Oncoogenicity Proposition against which functional impact information was assessed,
             in determining the strength and direction of support this information provides as evidence.
-          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantOncogenicityProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantOncogenicityProposition"
         strengthOfEvidenceProvided:
           description: >-
             The strength of support that an Evidence Line is determined to provide for or against the proposed

--- a/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
+++ b/schema/va-spec/ccv-2022/oncogenicity-functional-impact-evidence-line-profile-source.yaml
@@ -37,6 +37,8 @@ $defs:
             primaryCoding:
               code:
                 enum:
+                  - standalone
+                  - very strong
                   - strong
                   - moderate
                   - supporting
@@ -46,15 +48,6 @@ $defs:
           description: >-
             The Clingen/CGC/VICC-2022 criterion that was applied to interpret variant functional impact information
             as evidence for or against the assessed variant's oncogenicity.
-          properties:
-            reportedIn:
-               properties:
-                  pmid:
-                    const: 35101336
-                  name:
-                    const: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
-          required:
-            - reportedIn
         evidenceOutcome:
           description: >-
             The evidence outcome is a summary of the 'directionOfEvidenceProvided' and 'strengthOfEvidenceProvided' values,

--- a/schema/va-spec/ccv-2022/oncogenicity-study-statement-profile-source.yaml
+++ b/schema/va-spec/ccv-2022/oncogenicity-study-statement-profile-source.yaml
@@ -39,9 +39,8 @@ $defs:
             primaryCoding:
               code:
                 enum:
-                  - strong
-                  - moderate
-                  - weak
+                  - definitive
+                  - likely
               system:
                 const: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
         classification:
@@ -68,15 +67,6 @@ $defs:
           description: >-
             The method that specifies how the oncogenicity classification is ultimately assigned to the variant,
             based on assessment of evidence.
-          properties:
-            reportedIn:
-               properties:
-                  pmid:
-                    const: 35101336
-                  name:
-                    const: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
-          required:
-            - reportedIn
       required:
         - classification
         - specifiedBy

--- a/schema/va-spec/ccv-2022/oncogenicity-study-statement-profile-source.yaml
+++ b/schema/va-spec/ccv-2022/oncogenicity-study-statement-profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/ccv-2022/oncogenicity-study-statement-profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/ccv-2022/oncogenicity-study-statement-profile-source.yaml"
 title: Variant Oncogenicity Study Statement Profile (CCV 2022)
 description: >-
   Profile defined to align with terminology and conventions from the Clinical Genome Resource (ClinGen),
@@ -19,10 +19,10 @@ $defs:
       is associated with oncogenicity (positive or negative) - based on interpretation of the study's
       results.
     allOf:
-    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/Statement"
+    - $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/Statement"
     - properties:
         proposition:
-          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.1/base/json/VariantOncogenicityProposition"
+          $ref: "/ga4gh/schema/va-spec/1.0.0-ballot.2025-03.2/base/json/VariantOncogenicityProposition"
           description: >-
             A proposition about the oncogenicity of a varaint, for which the study provides evidence.
             The validity of this proposition, and the level of confidence/evidence supporting it,

--- a/schema/va-spec/ccv-2022/oncogenicity-study-statement-profile-source.yaml
+++ b/schema/va-spec/ccv-2022/oncogenicity-study-statement-profile-source.yaml
@@ -33,8 +33,6 @@ $defs:
             for or against the proposed oncogenicity of the assessed variant. Strength is evaluated relative
             to the direction indicated by the 'direction' attribute. The indicated enumeration constrains the nested
             MappableConcept.primaryCoding > Coding.code attribute when capturing evidence strength.
-            Conditional requirement: if direction is either 'supports' or 'disputes', then this
-            attribute is required.  If it is 'neutral', then this attribute is not allowed.
           properties:
             primaryCoding:
               code:
@@ -44,14 +42,6 @@ $defs:
               system:
                 const: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
         classification:
-          description: >-
-            The classification of the variant's oncogenicity, based on the CCV 2022 guidelines.
-            These classifications should coincide with the direction and strength values as follows:
-            'oncogenic' with supports-strong, 'likely oncogenic' with supports-moderate,
-            'benign' with disputes-strong, 'likely benign' with disputes-moderate 'uncertain significance'
-            can be one of three possibilities... supports-weak, disputes-weak or neutral for
-            uncertain significance (favoring pathogenic), uncertain significance (favoring benign) or
-            uncertain significance (favoring neither pathogenic nor benign).
           properties:
             primaryCoding:
               code:

--- a/tests/fixtures/VA-ClinVar-SCV-Example-001.yaml
+++ b/tests/fixtures/VA-ClinVar-SCV-Example-001.yaml
@@ -59,7 +59,7 @@ proposition:
 direction: supports
 strength:
   primaryCoding:
-    code: strong
+    code: definitive
     system: ACMG Guidelines, 2015
 classification:
   primaryCoding:

--- a/tests/fixtures/VA-ClinVar-SCV-Example-002.yaml
+++ b/tests/fixtures/VA-ClinVar-SCV-Example-002.yaml
@@ -17,7 +17,7 @@ proposition:
 direction: supports
 strength:
   primaryCoding:
-    code: moderate
+    code: likely
     system: ACMG Guidelines, 2015
 classification:
   primaryCoding:

--- a/tests/fixtures/Var-Path-Func-Impact-Evidence-Line-01.yaml
+++ b/tests/fixtures/Var-Path-Func-Impact-Evidence-Line-01.yaml
@@ -40,7 +40,7 @@ directionOfEvidenceProvided: supports
 strengthOfEvidenceProvided:
   primaryCoding:
     code: supporting
-    system: ga4gh-gks-term:path-functional-impact-strengthOfEvidenceProvided
+    system: ACMG Guidelines, 2015
 specifiedBy:
   type: Method
   id: PS3
@@ -52,5 +52,5 @@ specifiedBy:
 evidenceOutcome:
   primaryCoding:
     code: PS3_supporting
-    system: ga4gh-gks-term:path-functional-impact-evidenceOutcome
+    system: ACMG Guidelines, 2015
   name: ACMG 2015 PS3 Supporting Criterion Met

--- a/tests/fixtures/diagnostic-inline.yaml
+++ b/tests/fixtures/diagnostic-inline.yaml
@@ -1,18 +1,24 @@
 id: civic.eid:80
 type: Statement
 description: https://civicdb.org/evidence/80/summary
-
 direction: supports
 strength:
   id: civic.evidenceLevel:B
   name: Clinical evidence
+  primaryCoding:
+    code: Level B
+    system: AMP/ASCO/CAP (AAC) Guidelines, 2017
   mappings:
     - coding:
         code: e000005
         name: clinical cohort evidence
         system: https://go.osu.edu/evidence-codes
       relation: exactMatch
-
+classification:
+  name: oncogenic
+  primaryCoding:
+    code: Tier I -  positive
+    system: CIViC SOP AAC Guidelines, 2019
 proposition:
   type: VariantDiagnosticProposition
   predicate: isDiagnosticInclusionCriterionFor

--- a/tests/fixtures/diagnostic-inline.yaml
+++ b/tests/fixtures/diagnostic-inline.yaml
@@ -17,7 +17,7 @@ strength:
 classification:
   name: oncogenic
   primaryCoding:
-    code: Tier I -  positive
+    code: Tier I - Reduced Response
     system: CIViC SOP AAC Guidelines, 2019
 proposition:
   type: VariantDiagnosticProposition

--- a/tests/fixtures/diagnostic-inline.yaml
+++ b/tests/fixtures/diagnostic-inline.yaml
@@ -3,22 +3,17 @@ type: Statement
 description: https://civicdb.org/evidence/80/summary
 direction: supports
 strength:
-  id: civic.evidenceLevel:B
+  # id: civic.evidenceLevel:B
   name: Clinical evidence
   primaryCoding:
-    code: Level B
-    system: AMP/ASCO/CAP (AAC) Guidelines, 2017
+    code: B
+    system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
   mappings:
     - coding:
         code: e000005
         name: clinical cohort evidence
         system: https://go.osu.edu/evidence-codes
       relation: exactMatch
-classification:
-  name: oncogenic
-  primaryCoding:
-    code: Tier I - Reduced Response
-    system: CIViC SOP AAC Guidelines, 2019
 proposition:
   type: VariantDiagnosticProposition
   predicate: isDiagnosticInclusionCriterionFor

--- a/tests/fixtures/prognostic-inline.yaml
+++ b/tests/fixtures/prognostic-inline.yaml
@@ -3,22 +3,17 @@ type: Statement
 description: https://civicdb.org/evidence/82/summary
 direction: supports
 strength:
-  id: civic.evidenceLevel:B
+  # id: civic.evidenceLevel:B
   name: Clinical evidence
   primaryCoding:
-    code: Level B
-    system: AMP/ASCO/CAP (AAC) Guidelines, 2017
+    code: B
+    system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
   mappings:
     - coding:
         code: e000005
         name: clinical cohort evidence
         system: https://go.osu.edu/evidence-codes
       relation: exactMatch
-classification:
-  name: worse outcome
-  primaryCoding:
-    code: Tier I - Adverse Response
-    system: CIViC SOP AAC Guidelines, 2019
 proposition:
   type: VariantPrognosticProposition
   predicate: associatedWithWorseOutcomeFor
@@ -117,27 +112,27 @@ proposition:
           - RAFB1
       - name: description
         value: "BRAF mutations are found to be recurrent in many cancer types. Of
-        these, the mutation of valine 600 to glutamic acid (V600E) is the most prevalent.
-        V600E has been determined to be an activating mutation, and cells that harbor it,
-        along with other V600 mutations are sensitive to the BRAF inhibitor dabrafenib. It
-        is also common to use MEK inhibition as a substitute for BRAF inhibitors, and the
-        MEK inhibitor trametinib has seen some success in BRAF mutant melanomas. BRAF
-        mutations have also been correlated with poor prognosis in many cancer types,
-        although there is at least one study that questions this conclusion in papillary
-        thyroid cancer. Oncogenic BRAF mutations are divided into three categories that
-        determine their sensitivity to inhibitors. Class 1 BRAF mutations (V600) are
-        RAS-independent, signal as monomers and are sensitive to current RAF monomer
-        inhibitors. Class 2 BRAF mutations (K601E, K601N, K601T, L597Q, L597V, G469A,
-        G469V, G469R, G464V, G464E, and fusions) are RAS-independent, signaling as
-        constitutive dimers and are resistant to vemurafenib. Such mutants may be
-        sensitive to novel RAF dimer inhibitors or MEK inhibitors. Class 3 BRAF mutations
-        (D287H, V459L, G466V, G466E, G466A, S467L, G469E, N581S, N581I, D594N, D594G,
-        D594A, D594H, F595L, G596D, and G596R) with low or absent kinase activity are
-        RAS-dependent and they activate ERK by increasing their binding to activated RAS
-        and wild-type CRAF. Class 3 BRAF mutations coexist with mutations in RAS or NF1
-        in melanoma may be treated with MEK inhibitors. In epithelial tumors such as CRC
-        or NSCLC may be effectively treated with combinations that include inhibitors of
-        receptor tyrosine kinase."
+          these, the mutation of valine 600 to glutamic acid (V600E) is the most prevalent.
+          V600E has been determined to be an activating mutation, and cells that harbor it,
+          along with other V600 mutations are sensitive to the BRAF inhibitor dabrafenib. It
+          is also common to use MEK inhibition as a substitute for BRAF inhibitors, and the
+          MEK inhibitor trametinib has seen some success in BRAF mutant melanomas. BRAF
+          mutations have also been correlated with poor prognosis in many cancer types,
+          although there is at least one study that questions this conclusion in papillary
+          thyroid cancer. Oncogenic BRAF mutations are divided into three categories that
+          determine their sensitivity to inhibitors. Class 1 BRAF mutations (V600) are
+          RAS-independent, signal as monomers and are sensitive to current RAF monomer
+          inhibitors. Class 2 BRAF mutations (K601E, K601N, K601T, L597Q, L597V, G469A,
+          G469V, G469R, G464V, G464E, and fusions) are RAS-independent, signaling as
+          constitutive dimers and are resistant to vemurafenib. Such mutants may be
+          sensitive to novel RAF dimer inhibitors or MEK inhibitors. Class 3 BRAF mutations
+          (D287H, V459L, G466V, G466E, G466A, S467L, G469E, N581S, N581I, D594N, D594G,
+          D594A, D594H, F595L, G596D, and G596R) with low or absent kinase activity are
+          RAS-dependent and they activate ERK by increasing their binding to activated RAS
+          and wild-type CRAF. Class 3 BRAF mutations coexist with mutations in RAS or NF1
+          in melanoma may be treated with MEK inhibitors. In epithelial tumors such as CRC
+          or NSCLC may be effectively treated with combinations that include inhibitors of
+          receptor tyrosine kinase."
 specifiedBy:
   id: civic.methods:2019
   name: CIViC Curation SOP (2019)

--- a/tests/fixtures/prognostic-inline.yaml
+++ b/tests/fixtures/prognostic-inline.yaml
@@ -5,12 +5,20 @@ direction: supports
 strength:
   id: civic.evidenceLevel:B
   name: Clinical evidence
+  primaryCoding:
+    code: Level B
+    system: AMP/ASCO/CAP (AAC) Guidelines, 2017
   mappings:
     - coding:
         code: e000005
         name: clinical cohort evidence
         system: https://go.osu.edu/evidence-codes
       relation: exactMatch
+classification:
+  name: worse outcome
+  primaryCoding:
+    code: Tier I - Poor Outcome
+    system: CIViC SOP AAC Guidelines, 2019
 proposition:
   type: VariantPrognosticProposition
   predicate: associatedWithWorseOutcomeFor

--- a/tests/fixtures/prognostic-inline.yaml
+++ b/tests/fixtures/prognostic-inline.yaml
@@ -17,7 +17,7 @@ strength:
 classification:
   name: worse outcome
   primaryCoding:
-    code: Tier I - Poor Outcome
+    code: Tier I - Adverse Response
     system: CIViC SOP AAC Guidelines, 2019
 proposition:
   type: VariantPrognosticProposition

--- a/tests/fixtures/therapeutic-response-inline.yaml
+++ b/tests/fixtures/therapeutic-response-inline.yaml
@@ -7,21 +7,16 @@ description: A phase III clinical trial (NCT00949650) found that median progress
 direction: supports
 strength:
   # id: civic.evidenceLevel:B
-  # name: Clinical evidence
+  name: Clinical evidence
   primaryCoding:
-    code: "Level B"
-    system: "AMP/ASCO/CAP (AAC) Guidelines, 2017"
+    code: B
+    system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
   mappings:
     - coding:
         code: e000005
         name: clinical cohort evidence
         system: https://go.osu.edu/evidence-codes
       relation: exactMatch
-classification:
-  name: confers sensitivity
-  primaryCoding:
-    code: Tier I - Sensitivity/Response
-    system: CIViC SOP AAC Guidelines, 2019
 proposition:
   type: VariantTherapeuticResponseProposition
   predicate: predictsSensitivityTo
@@ -139,18 +134,18 @@ proposition:
           - mENA
       - name: description
         value: "EGFR is widely recognized for its importance in cancer. Amplification
-        and mutations have been shown to be driving events in many cancer types. Its
-        role in non-small cell lung cancer, glioblastoma and basal-like breast cancers
-        has spurred many research and drug development efforts. Tyrosine kinase inhibitors
-        have shown efficacy in EGFR amplfied tumors, most notably gefitinib and erlotinib.
-        Mutations in EGFR have been shown to confer resistance to these drugs, particularly
-        the variant T790M, which has been functionally characterized as a resistance
-        marker for both of these drugs. The later generation TKI's have seen some
-        success in treating these resistant cases, and targeted sequencing of the
-        EGFR locus has become a common practice in treatment of non-small cell lung
-        cancer. \nOverproduction of ligands is another possible mechanism of activation
-        of EGFR. ERBB ligands include EGF, TGF-a, AREG, EPG, BTC, HB-EGF, EPR and
-        NRG1-4 (for detailed information please refer to the respective ligand section)."
+          and mutations have been shown to be driving events in many cancer types. Its
+          role in non-small cell lung cancer, glioblastoma and basal-like breast cancers
+          has spurred many research and drug development efforts. Tyrosine kinase inhibitors
+          have shown efficacy in EGFR amplfied tumors, most notably gefitinib and erlotinib.
+          Mutations in EGFR have been shown to confer resistance to these drugs, particularly
+          the variant T790M, which has been functionally characterized as a resistance
+          marker for both of these drugs. The later generation TKI's have seen some
+          success in treating these resistant cases, and targeted sequencing of the
+          EGFR locus has become a common practice in treatment of non-small cell lung
+          cancer. \nOverproduction of ligands is another possible mechanism of activation
+          of EGFR. ERBB ligands include EGF, TGF-a, AREG, EPG, BTC, HB-EGF, EPR and
+          NRG1-4 (for detailed information please refer to the respective ligand section)."
 specifiedBy:
   id: civic.methods:2019
   name: CIViC Curation SOP (2019)

--- a/tests/fixtures/tr-statement-inline.yaml
+++ b/tests/fixtures/tr-statement-inline.yaml
@@ -6,14 +6,22 @@ description: A phase III clinical trial (NCT00949650) found that median progress
   95% CI, 0.34 to 0.65; P = 0.001).
 direction: supports
 strength:
-  id: civic.evidenceLevel:B
-  name: Clinical evidence
+  # id: civic.evidenceLevel:B
+  # name: Clinical evidence
+  primaryCoding:
+    code: "Level B"
+    system: "AMP/ASCO/CAP (AAC) Guidelines, 2017"
   mappings:
     - coding:
         code: e000005
         name: clinical cohort evidence
         system: https://go.osu.edu/evidence-codes
       relation: exactMatch
+classification:
+  name: confers sensitivity
+  primaryCoding:
+    code: Tier I - Sensitivity/Response
+    system: CIViC SOP AAC Guidelines, 2019
 proposition:
   type: VariantTherapeuticResponseProposition
   predicate: predictsSensitivityTo

--- a/tests/test_definitions.yaml
+++ b/tests/test_definitions.yaml
@@ -73,18 +73,18 @@ tests:
   - test_file: therapeuticAgent.yaml
     namespace: gks-core
     definition: MappableConcept
-  - test_file: tr-statement-inline.yaml
-    namespace: va-spec.aac-2017
-    definition: VariantTherapeuticResponseStudyStatement
-  - test_file: tr-statement-inline.yaml
+  # - test_file: tr-classification-inline.yaml
+  #   namespace: va-spec.aac-2017
+  #   definition: VariantTherapeuticResponseStudyStatement
+  - test_file: therapeutic-response-inline.yaml
     namespace: va-spec.base
     definition: Statement
   - test_file: diagnostic-inline.yaml
-    namespace: va-spec.aac-2017
-    definition: VariantDiagnosticStudyStatement
+    namespace: va-spec.base
+    definition: Statement
   - test_file: prognostic-inline.yaml
-    namespace: va-spec.aac-2017
-    definition: VariantPrognosticStudyStatement
+    namespace: va-spec.base
+    definition: Statement
   - test_file: cohort-allele-freq-test.yaml
     namespace: va-spec.base
     definition: CohortAlleleFrequencyStudyResult


### PR DESCRIPTION
…ource.yaml

Added structure and descriptions needed to include AAC-based constraints in this profile, as we agreed on the 3-12-25 call.  

"TO DO" comments indicate where Alex/Kori will need to add specific values for enumerations (if they deem enums appropriate for these attributes).