### PR TITLE
feat: make `InformationEntity.contributions` ordered

### DIFF
--- a/schema/va-spec/base/def/CohortAlleleFrequencyStudyResult.rst
+++ b/schema/va-spec/base/def/CohortAlleleFrequencyStudyResult.rst
@@ -61,7 +61,7 @@ Some CohortAlleleFrequencyStudyResult attributes are inherited from :ref:`StudyR
       -
                         .. raw:: html
 
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Ordered">&#8595;</span>
       - :ref:`Contribution`
       - 0..m
       - Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.

--- a/schema/va-spec/base/def/EvidenceLine.rst
+++ b/schema/va-spec/base/def/EvidenceLine.rst
@@ -61,7 +61,7 @@ Some EvidenceLine attributes are inherited from :ref:`InformationEntity`.
       -
                         .. raw:: html
 
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Ordered">&#8595;</span>
       - :ref:`Contribution`
       - 0..m
       - Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.

--- a/schema/va-spec/base/def/ExperimentalVariantFunctionalImpactStudyResult.rst
+++ b/schema/va-spec/base/def/ExperimentalVariantFunctionalImpactStudyResult.rst
@@ -56,7 +56,7 @@ Some ExperimentalVariantFunctionalImpactStudyResult attributes are inherited fro
       -
                         .. raw:: html
 
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Ordered">&#8595;</span>
       - :ref:`Contribution`
       - 0..m
       - Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.

--- a/schema/va-spec/base/def/InformationEntity.rst
+++ b/schema/va-spec/base/def/InformationEntity.rst
@@ -66,7 +66,7 @@ Some InformationEntity attributes are inherited from :ref:`gks-core:Entity`.
       -
                         .. raw:: html
 
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Ordered">&#8595;</span>
       - :ref:`Contribution`
       - 0..m
       - Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.

--- a/schema/va-spec/base/def/Statement.rst
+++ b/schema/va-spec/base/def/Statement.rst
@@ -61,7 +61,7 @@ Some Statement attributes are inherited from :ref:`InformationEntity`.
       -
                         .. raw:: html
 
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Ordered">&#8595;</span>
       - :ref:`Contribution`
       - 0..m
       - Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.

--- a/schema/va-spec/base/def/StudyResult.rst
+++ b/schema/va-spec/base/def/StudyResult.rst
@@ -66,7 +66,7 @@ Some StudyResult attributes are inherited from :ref:`InformationEntity`.
       -
                         .. raw:: html
 
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Ordered">&#8595;</span>
       - :ref:`Contribution`
       - 0..m
       - Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.

--- a/schema/va-spec/base/def/TumorVariantFrequencyStudyResult.rst
+++ b/schema/va-spec/base/def/TumorVariantFrequencyStudyResult.rst
@@ -61,7 +61,7 @@ Some TumorVariantFrequencyStudyResult attributes are inherited from :ref:`StudyR
       -
                         .. raw:: html
 
-                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
+                            <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Ordered">&#8595;</span>
       - :ref:`Contribution`
       - 0..m
       - Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.

--- a/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
+++ b/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
@@ -50,7 +50,7 @@
       },
       "contributions": {
          "type": "array",
-         "ordered": false,
+         "ordered": true,
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.0.0/base/json/Contribution"
          },

--- a/schema/va-spec/base/json/EvidenceLine
+++ b/schema/va-spec/base/json/EvidenceLine
@@ -51,7 +51,7 @@
       },
       "contributions": {
          "type": "array",
-         "ordered": false,
+         "ordered": true,
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.0.0/base/json/Contribution"
          },

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
@@ -38,7 +38,7 @@
       },
       "contributions": {
          "type": "array",
-         "ordered": false,
+         "ordered": true,
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.0.0/base/json/Contribution"
          },

--- a/schema/va-spec/base/json/Statement
+++ b/schema/va-spec/base/json/Statement
@@ -51,7 +51,7 @@
       },
       "contributions": {
          "type": "array",
-         "ordered": false,
+         "ordered": true,
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.0.0/base/json/Contribution"
          },

--- a/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
+++ b/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
@@ -50,7 +50,7 @@
       },
       "contributions": {
          "type": "array",
-         "ordered": false,
+         "ordered": true,
          "items": {
             "$ref": "/ga4gh/schema/va-spec/1.0.0/base/json/Contribution"
          },

--- a/schema/va-spec/base/va-core-source.yaml
+++ b/schema/va-spec/base/va-core-source.yaml
@@ -45,7 +45,7 @@ $defs:
           a *type* of method applied (e.g. 'Transmission Electron Microscopy').
       contributions:
         type: array
-        ordered: false
+        ordered: true
         items:
           $ref: "#/$defs/Contribution"
         description: >-


### PR DESCRIPTION
close #361

* Contributions are now a list instead of a set


# Why do we need this?

We need this for our work in GKS ClinVar This. We want to build a submission utility that allows us to submit the most recent contribution.

Implementers will be able to decide if the order of contributions is meaningful.