### PR TITLE
feat: make `ConditionSet` nestable to represent complex relationships

### DIFF
--- a/schema/va-spec/base/def/ConditionSet.rst
+++ b/schema/va-spec/base/def/ConditionSet.rst
@@ -4,7 +4,7 @@
 
 **Computational Definition**
 
-A set of conditions (diseases, phenotypes, traits). A set of two or more conditions that co-occur in the same patient/subject, or are manifest individually in a different subset of participants in a research study.
+A set of conditions (diseases, phenotypes, traits) that occur together or are related, depending on the membership operator, and may manifest together in the same patient or individually in a different subset of participants in a research study.
 
 **Information Model**
 
@@ -39,9 +39,9 @@ Some ConditionSet attributes are inherited from :ref:`gks-core:Element`.
                         .. raw:: html
 
                             <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
-      - :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`ConditionSet`
       - 2..m
-      - A list of conditions (diseases, phenotypes, traits) that are co-occurring.
+      - A list of conditions (diseases, phenotypes, traits) that are co-occurring or related, depending on the membership operator.
    *  - membershipOperator
       -
       - string

--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -33,17 +33,21 @@ $defs:
     maturity: trial use
     inherits: gks-core:Element
     description: >-
-      A set of conditions (diseases, phenotypes, traits).
-      A set of two or more conditions that co-occur in the same patient/subject, or are manifest
-      individually in a different subset of participants in a research study.
+      A set of conditions (diseases, phenotypes, traits) that occur together or are
+      related, depending on the membership operator, and may manifest together in the
+      same patient or individually in a different subset of participants in a research
+      study.
     properties:
       conditions:
         type: array
         ordered: false
         items:
-          $refCurie: gks.core:MappableConcept
+          oneOf:
+            - $refCurie: gks.core:MappableConcept
+            - $ref: "#/$defs/ConditionSet"
         description: >-
-          A list of conditions (diseases, phenotypes, traits) that are co-occurring.
+          A list of conditions (diseases, phenotypes, traits) that are co-occurring or
+          related, depending on the membership operator.
         minItems: 2
       membershipOperator:
         description: >-

--- a/schema/va-spec/base/json/ConditionSet
+++ b/schema/va-spec/base/json/ConditionSet
@@ -4,7 +4,7 @@
    "title": "ConditionSet",
    "type": "object",
    "maturity": "trial use",
-   "description": "A set of conditions (diseases, phenotypes, traits). A set of two or more conditions that co-occur in the same patient/subject, or are manifest individually in a different subset of participants in a research study.",
+   "description": "A set of conditions (diseases, phenotypes, traits) that occur together or are related, depending on the membership operator, and may manifest together in the same patient or individually in a different subset of participants in a research study.",
    "properties": {
       "id": {
          "type": "string",
@@ -23,9 +23,16 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+            "oneOf": [
+               {
+                  "$ref": "/ga4gh/schema/va-spec/1.0.0/base/json/ConditionSet"
+               },
+               {
+                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               }
+            ]
          },
-         "description": "A list of conditions (diseases, phenotypes, traits) that are co-occurring.",
+         "description": "A list of conditions (diseases, phenotypes, traits) that are co-occurring or related, depending on the membership operator.",
          "minItems": 2
       },
       "membershipOperator": {

--- a/tests/fixtures/conditionset-complex.yaml
+++ b/tests/fixtures/conditionset-complex.yaml
@@ -1,0 +1,37 @@
+membershipOperator: AND
+conditions:
+  - conceptType: Disease
+    id: civic.did:3387
+    mappings:
+      - coding:
+          code: DOID:0081279
+          system: https://disease-ontology.org/?id=
+        relation: exactMatch
+    name: Diffuse Astrocytoma, MYB- Or MYBL1-altered
+  - conditions:
+      - conceptType: Phenotype
+        id: civic.phenotype:8121
+        mappings:
+          - coding:
+              code: HP:0011463
+              system: https://hpo.jax.org/browse/term/
+            relation: exactMatch
+        name: Childhood onset
+      - conceptType: Phenotype
+        id: civic.phenotype:2656
+        mappings:
+          - coding:
+              code: HP:0003621
+              id: HP:0003621
+              system: https://hpo.jax.org/browse/term/
+            relation: exactMatch
+        name: Juvenile onset
+      - conceptType: Phenotype
+        id: civic.phenotype:2643
+        mappings:
+          - coding:
+              code: HP:0003581
+              system: https://hpo.jax.org/browse/term/
+            relation: exactMatch
+        name: Adult onset
+    membershipOperator: OR

--- a/tests/test_definitions.yaml
+++ b/tests/test_definitions.yaml
@@ -34,6 +34,9 @@ tests:
   - test_file: conditionset.yaml
     namespace: va-spec.base
     definition: ConditionSet
+  - test_file: conditionset-complex.yaml
+    namespace: va-spec.base
+    definition: ConditionSet
   - test_file: therapy-group.yaml
     namespace: va-spec.base
     definition: TherapyGroup


### PR DESCRIPTION
close #343

* `ConditionSet.conditions` additionally allows `ConditionSet`

# Why do we need this?

We need this work to represent CIViC assertions in GKS ClinVar This and are currently blocked since we cannot represent complex relationships at the moment. 