### PR TITLE
docs: add annotated-code-block functionality to RST examples

### DIFF
--- a/docs/source/_ext/annotations.py
+++ b/docs/source/_ext/annotations.py
@@ -1,0 +1,133 @@
+"""Provide annotated-code-block directive for Sphinx.
+
+Behaves exactly like a `.. code-block`, but replaces ALL comments with tooltips that
+contain the comment text. This is useful for cases like example YAML files where we
+might want to include lots of details about a given line.
+
+Example
+
+  .. annotated-code-block:: yaml
+
+     SCV000778434.1:
+       id: SCV000778434.1
+       type: Statement  # This is a long comment describing this field. It will be replaced by a tooltip.
+
+Notes
+ * Indentation of the comment gets ignored, so don't bother lining them up.
+
+Limitations (variably addressable if necessary)
+ * Replaces ALL comments with tooltips
+ * If a comment is on its own line, it'll still get replaced by a tooltip. Don't even try
+   a multiline comment.
+ * Assumes "#" for comment character (works for YAML, nothing else has been tested)
+ * Tooltip always goes right, even if it's all the way to the right of the viewport.
+ * Bleeds to the right of a viewport a bit if the line is too long (you can scroll, but
+   it's annoying -- still better than before)
+
+It works by post-processing the generated docs; it has no direct access to the parsed code
+block or surrounding RST, only the HTML output. This creates some limitations, but
+injecting the annotation in during code generation was causing some problems with syntax
+highlighting.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+from sphinx.highlighting import PygmentsBridge
+
+# Pattern to identify comment-strings as highlighted by Pygments
+COMMENT_SPAN_RE = re.compile(
+    r"(?P<ws><span class=\"w\">[ \t]*</span>)?"
+    r"(?P<comment><span class=\"c1\">#(?P<space>\s*)"
+    r"(?P<text>.*?)</span>)",
+    re.DOTALL,
+)
+
+
+def replace_comment_spans_with_tooltips(highlighted: str) -> str:
+    """Replace highlighted code comment spans with a tooltip button.
+
+    - Removes the comment marker '#'
+    - Moves comment text into tooltip
+    - Collapses any preceding whitespace span to a single space before the button
+
+    :param highlighted:
+    """
+
+    def repl(m: re.Match[str]) -> str:
+        # This is already HTML-escaped by Pygments, so we can embed directly
+        text_html = (m.group("text") or "").lstrip()
+
+        # handle empty comment
+        if not text_html:
+            return ""
+
+        widget = (
+            '<span class="ann-wrap">'
+            '<button type="button" class="ann-btn" aria-label="annotation">+</button>'
+            f'<span class="ann-tip" role="tooltip" hidden>{text_html}</span>'
+            "</span>"
+        )
+        return widget
+
+    return COMMENT_SPAN_RE.sub(repl, highlighted)
+
+
+class annotated_code_block(nodes.General, nodes.Element):
+    """A custom node that stores code + language."""
+
+
+class AnnotatedCodeBlock(Directive):
+    """Block of "annotated" code (code + added tooltip)
+
+    Notes:
+      - This post-processes the *highlighted HTML*, so Pygments is not disturbed.
+      - It currently targets Pygments comment class "c1" which is typical for YAML.
+    """
+
+    required_arguments = 1  # language of the code block
+    has_content = True
+    option_spec: Dict[str, Any] = {}
+
+    def run(self) -> List[nodes.Node]:
+        lang = self.arguments[0].strip()
+        code = "\n".join(self.content)
+
+        node = annotated_code_block()
+        node["language"] = lang
+        node["code"] = code
+        return [node]
+
+
+def visit_annotated_code_block_html(self: Any, node: annotated_code_block) -> None:
+    lang: str = node["language"]
+    code: str = node["code"]
+
+    highlighter = PygmentsBridge("html", self.config.pygments_style)
+    highlighted = highlighter.highlight_block(code, lang, linenos=False)
+
+    highlighted = replace_comment_spans_with_tooltips(highlighted)
+
+    self.body.append(highlighted)
+    raise nodes.SkipNode
+
+
+def setup(app: Any) -> Dict[str, Any]:
+    app.add_node(
+        annotated_code_block,
+        html=(visit_annotated_code_block_html, lambda self, node: None),
+    )
+    app.add_directive("annotated-code-block", AnnotatedCodeBlock)
+
+    app.add_css_file("ann.css")
+    app.add_js_file("ann.js")
+
+    return {
+        "version": "0.1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/docs/source/_static/ann.css
+++ b/docs/source/_static/ann.css
@@ -1,0 +1,47 @@
+/* Custom css for the `annotated-code-block` directive. */
+
+div.highlight, div.highlight pre {
+  overflow: visible;
+}
+
+.ann-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.ann-btn {
+  font: inherit;
+  padding: 0 0.25em;
+  margin-left: 0.25em;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.ann-tip {
+  position: absolute;
+  z-index: 9999;
+
+  top: 1.3em;
+  left: 0;
+
+  display: block;
+  min-width: 20rem;
+  max-width: min(55rem, 90vw);
+  padding: 0.4em 0.6em;
+
+  border: 1px solid;
+  border-radius: 0.4em;
+
+  white-space: normal;
+
+  pointer-events: auto;
+
+  background-color: var(--color-background-primary, #ffffff);
+  color: var(--color-foreground-primary, #000000);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+  isolation: isolate;
+}
+
+.ann-tip[hidden] {
+  display: none;
+}

--- a/docs/source/_static/ann.js
+++ b/docs/source/_static/ann.js
@@ -1,0 +1,26 @@
+// Custom JS for the annotated-code-block directive, adding tooltip functionality.
+
+function closeAllTooltips(exceptTip) {
+  document.querySelectorAll(".ann-tip").forEach((tip) => {
+    if (tip !== exceptTip) tip.hidden = true;
+  });
+}
+
+document.addEventListener("click", (e) => {
+  const btn = e.target.closest(".ann-btn");
+
+  if (!btn) {
+    closeAllTooltips(null);
+    return;
+  }
+
+  const wrap = btn.closest(".ann-wrap");
+  if (!wrap) return;
+
+  const tip = wrap.querySelector(".ann-tip");
+  if (!tip) return;
+
+  const newState = !tip.hidden;
+  closeAllTooltips(tip);
+  tip.hidden = newState;
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,10 @@
 # -- GIT branch and release info --------------------------------------------------------------
 import os
 import requests
+import sys
 import subprocess
+from pathlib import Path
+
 
 def get_rtd_branch_from_github(repo="ga4gh/va-spec", default="main"):
     """
@@ -19,7 +22,7 @@ def get_rtd_branch_from_github(repo="ga4gh/va-spec", default="main"):
             result = subprocess.run(
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                 capture_output=True,
-                check=True
+                check=True,
             )
             branch = result.stdout.decode().strip()
             return branch if branch != "HEAD" else default
@@ -39,7 +42,7 @@ def get_rtd_branch_from_github(repo="ga4gh/va-spec", default="main"):
         response = requests.get(
             f"https://api.github.com/repos/{repo}/pulls/{pr_number}",
             headers=headers,
-            timeout=5
+            timeout=5,
         )
         if response.status_code == 200:
             return response.json()["head"]["ref"]  # actual source branch name
@@ -49,6 +52,7 @@ def get_rtd_branch_from_github(repo="ga4gh/va-spec", default="main"):
         print(f"GitHub API exception: {e}")
 
     return f"pull/{pr_number}"
+
 
 # def get_git_branch_or_default(default="main"):
 #     """
@@ -74,6 +78,7 @@ def get_rtd_branch_from_github(repo="ga4gh/va-spec", default="main"):
 #     except subprocess.CalledProcessError:
 #         return default
 
+
 def get_exact_git_tag():
     """
     Returns the exact tag for the current Git commit, if one exists.
@@ -83,7 +88,7 @@ def get_exact_git_tag():
         result = subprocess.run(
             ["git", "describe", "--tags", "--exact-match"],
             capture_output=True,
-            check=True
+            check=True,
         )
         tag = result.stdout.decode().strip()
         return tag if tag else None
@@ -94,16 +99,19 @@ def get_exact_git_tag():
 # -- Project information -----------------------------------------------------
 
 print("*!*!*!*!* Branch detected:", get_rtd_branch_from_github())
-print("RTD env:", {
-    "READTHEDOCS": os.environ.get("READTHEDOCS"),
-    "READTHEDOCS_VERSION": os.environ.get("READTHEDOCS_VERSION"),
-    "READTHEDOCS_VERSION_TYPE": os.environ.get("READTHEDOCS_VERSION_TYPE"),
-})
+print(
+    "RTD env:",
+    {
+        "READTHEDOCS": os.environ.get("READTHEDOCS"),
+        "READTHEDOCS_VERSION": os.environ.get("READTHEDOCS_VERSION"),
+        "READTHEDOCS_VERSION_TYPE": os.environ.get("READTHEDOCS_VERSION_TYPE"),
+    },
+)
 
-project = 'GA4GH Variant Annotation Specification'
-copyright = '2024, GA4GH VA Contributors'
-author = 'Committers'
-master_doc = 'index'
+project = "GA4GH Variant Annotation Specification"
+copyright = "2024, GA4GH VA Contributors"
+author = "Committers"
+master_doc = "index"
 # get the release from the git tag if available, otherwise use the branch name
 release = get_exact_git_tag()
 if release == None:
@@ -111,7 +119,7 @@ if release == None:
     release = get_rtd_branch_from_github(default="1.0")
 
 # Load static rst_epilog from file
-rst_epilog_fn = os.path.join(os.path.dirname(__file__), 'rst_epilog')
+rst_epilog_fn = os.path.join(os.path.dirname(__file__), "rst_epilog")
 with open(rst_epilog_fn, encoding="utf-8") as f:
     static_epilog = f.read().format(release=release)
 
@@ -137,7 +145,7 @@ with open(link_file_path, encoding="utf-8") as f:
         if "=" in line:
             label, filepath = [part.strip() for part in line.split("=", 1)]
             url = f"{github_base}/{filepath}"
-            label_text = label.replace('_', ' ').title()
+            label_text = label.replace("_", " ").title()
             link = f".. |{label}| replace:: `{label_text} <{url}>`__"
             dynamic_links.append(link)
 
@@ -145,19 +153,27 @@ with open(link_file_path, encoding="utf-8") as f:
 dynamic_epilog = "\n".join(dynamic_links)
 
 # Combine both static and dynamic epilogs
-rst_epilog = static_epilog  + "\n" + dynamic_epilog
+rst_epilog = static_epilog + "\n" + dynamic_epilog
 
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))  # allows importing "_ext.*" next to conf.py
+sys.path.insert(
+    0, str(HERE / "_ext")
+)  # allows importing "annotations" directly (optional)
+
 extensions = [
-    'sphinx.ext.todo'
+    "sphinx.ext.todo",
+    "_ext.annotations",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -173,24 +189,25 @@ todo_emit_warnings = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 html_theme_options = {
-    'navigation_depth': 5,  # Increase to 4 levels of nested sections
-    'collapse_navigation': False
+    "navigation_depth": 5,  # Increase to 4 levels of nested sections
+    "collapse_navigation": False,
 }
-html_logo = 'images/GA-logo.png'
+html_logo = "images/GA-logo.png"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-html_css_files = ['theme_overrides.css']
+html_css_files = ["theme_overrides.css"]
 
 # Sidebars
 
-html_sidebars = { '**': ['globaltoc.html', 'relations.html',
-                         'sourcelink.html', 'searchbox.html'] }
+html_sidebars = {
+    "**": ["globaltoc.html", "relations.html", "sourcelink.html", "searchbox.html"]
+}
 html_context = {
     "conf_py_path": "/docs/source/",
     "display_github": True,

--- a/docs/source/examples/acmg-variant-pathogenicity-statement-with-evidence.rst
+++ b/docs/source/examples/acmg-variant-pathogenicity-statement-with-evidence.rst
@@ -30,10 +30,9 @@ A few additional notes about this example:
 
 **Data**:
 
-.. note:: Comments in the example below will be easier to view in the |acmg_pathogenicity_statement_with_evidence_example_source_yaml|, which affords the option of a wider browser window.
-   We recommend opening this example side-by-side with the figure above, and tracking how the data reflects the diagrammed structure and semantics.
+.. note:: We recommend opening this example side-by-side with the figure above, and tracking how the data reflects the diagrammed structure and semantics.
 
-.. code-block:: yaml
+.. annotated-code-block:: yaml
 
  ex.Statement001:              # Based on the ClinVar record SCV000778434.1
   id: ex:Statement001

--- a/docs/source/examples/acmg-variant-pathogenicity-statement-with-evidence.rst
+++ b/docs/source/examples/acmg-variant-pathogenicity-statement-with-evidence.rst
@@ -35,233 +35,233 @@ A few additional notes about this example:
 .. annotated-code-block:: yaml
 
  ex.Statement001:              # Based on the ClinVar record SCV000778434.1
-  id: ex:Statement001
-  type: Statement              # Formal type in the model is 'Statement', but the data aligns with the "Variant Pathogenicity Statement (ACMG 2015)" Community Profile.
-  proposition:                 # a Proposition object captures the possible fact assessed by the Statement, using a subject, predicate, object, qualifier (SPOQ) semantic modeling pattern.
-    id: ex:Proposition001      # the proposition here is that "NM_004700.4:c.803CCT[1] is causal for AD nonsyndromic hearing loss 2A"
-    type: VariantPathogenicityProposition
-    subjectVariant: ex:Variant001    # 'subjectVariant' specializes the VA Core 'subject' attribute. The full representation of the NM_004700.4:c.803CCT[1] KCNQ4 variant is not included.
-    predicate: isCausalFor           # the predicate for this Statement profile is fixed at 'isCausalFor'
-    objectCondition:                 # 'objectCondition' specializes the VA Core 'object' attribute.
-      id: clinvar.trait/939    # this is a MappableConcept object that represents the Condition, using names/codes from existing code systems
-      conceptType: Disease
-      name: Autosomal dominant nonsyndromic hearing loss 2A    # the name for the concept as assigned by the data provider
-      primaryCoding:           # holds a Coding object, where the concept is defined in the 'code' or 'name' field
-        code: C2677637         # the code from the MedGen terminology for AD nonsyndromic hearing loss 2A
-        system: https://www.ncbi.nlm.nih.gov/medgen/
-        iris:
-          - http://identifiers.org/medgen/C2677637
-    penetranceQualifier:       # holds a MappableConcept that reports qualifying penetrance information about the object condition (here, that the statement holds for high penetrance AD hearing loss)
-      primaryCoding:
-        code: high
-        system: ga4gh-gks-term:pathogenicity-penetrance-qualifier   # code system here is a locally defined placeholder, until we formalize terminological standards for use in the VA-Spec
-      name: high
-  direction: supports          # an enumerated string that indicates the Statement 'supports' the Proposition as true
-  strength:                    # holds a MappableConcept reporting that confidence/evidence for this stated support
-    primaryCoding:
-      code: definitive         # the code here is a term based on language used in the ACMG guidelines, as ACMG does not provide a formal code system for this
-      system: ACMG Guidelines, 2015
-  classification:              # holds a MappableConcept reporting the final ACMG classification of the subject variant  to be 'pathogenic'
-    primaryCoding:
-      code: pathogenic         # the code here is a term based on language in the ACMG guidelines, as ACMG does not provide a formal code system for this
-      system: ACMG Guidelines, 2015
-  contributions:               # a list of Contribution objects, each describing how an agent contributed to the Statement
-    - type: Contribution
-      contributor:             # reports who made this contribution
-        id: clinvar.submitter/500139
-        type: Agent
-        name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
-      activityType:            # reports the type of contribution that was made (here an evaluation activity)
-        name: evaluated
-        mappings:
-          - coding:
-              code: cg000011
-              system: https://dataexchange.clinicalgenome.org/codes/
-            relation: exactMatch
-      date: '2015-08-20'       # reports when this contribution was performed
-    - type: Contribution
-      contributor:
-        id: clinvar.submitter/500139
-        type: Agent
-        name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
-      activityType:
-        name: submitted
-        mappings:
-          - coding:
-              code: cg000010
-              system: https://dataexchange.clinicalgenome.org/codes/
-            relation: exactMatch
-      date: '2018-06-12'
-  specifiedBy:                 # holds a Method object describing guidelines followed in generating the knowledge reported in the Statement
-    type: Method
-    name: ClinGen Hearing Loss Expert Panel Specifications to the ACMG/AMP Variant Interpretation Guidelines
-    reportedIn:                # a document that describes the Method
-      type: Document
-      urls:
-        - https://clinicalgenome.org/docs/clingen-hearing-loss-expert-panel-specifications-to-the-acmg-amp-variant-interpretation-guidelines/
-  hasEvidenceLines:            # holds EvidenceLine objects describing how difference types of evidence was interpreted to support the root Statement
-  - id: ex:EvidenceLine001     # an Evidence Line based on cohort allele frequency data from gnomAD (https://gnomad.broadinstitute.org/)
-    type: EvidenceLine         # uses the core EvidenceLine class as its type, but validated against the VariantPathogenicityEvidenceLine Profile
-    targetProposition: ex:Proposition001     # the possible fact against which evidence information is assessed in this EvidenceLine (typically, as here, this is the same proposition as asserted in the root Statement it supports)
-    hasEvidenceItems:          # the information interpreted as evidence in building this Evidence Line
-    - id: ex:StudyResult001    # here, the evidence consists of a single StudyResult, which collects several allele frequency data items about the 1-10120-T-G allele.
-      type: CohortAlleleFrequencyStudyResult
-      name: Overall Cohort Allele Frequency for 1-40819444_40819446-del
-      focusAllele: ex:Variant001  # the KCNQ4 variant that data included in this Result are about (the full representation of the variant is not included)
-      focusAlleleFrequency: 0
-      focusAlleleCount: 0      # three specific data items produced by the analysis are collected in this StudyResult (focus allele frequency, focus allele count, and locus allele count)
-      locusAlleleCount: 34086
-      sourceDataSet:           # the gnomAD dataset from which the data included in this Result were pulled.
-        id: gnomad4.1.0
-        type: DataSet
-        name: gnomAD v4.1.0
-        version: 4.1.0
-      cohort:                  # a description of the cohort within the gnomad dataset interrogated in the analysis (here, the full gnomad population)
-        id: ALL
-        name: Overall
-        type: StudyGroup
-      specifiedBy:             # holds a Method object describing protocols and guidelines followed in generating the data reported in the Study Result
-        type: Method
-        name: gnomAD methods
-        reportedIn:            # a document that describes the Method (this is all we are given about this Method in the source data)
-          type: Document
-          name: gnomAD help documentation
-          urls:
-            - "https://gnomad.broadinstitute.org/help"
-    directionOfEvidenceProvided: supports   # reports that the frequency evidence 'supports' the target proposition (as opposed to disputing it)
-    strengthOfEvidenceProvided:
-      primaryCoding:
-        code: moderate        # reports that this supporting evidence is of 'moderate' strength
-        system: ACMG Guidelines, 2015
-    evidenceOutcome:          # holds a single term summarizing evidence direction and strength assessments, using community-specific vocabulary ...
-      primaryCoding:
-        code: PM2_moderate    # ... here, that the evidence line provides moderate evidence for Pathogenicity, based on the ACMG PM2 criteria
-        system: ACMG Guidelines, 2015
-      name: ACMG 2015 PM2 Moderate Criterion Met
-    specifiedBy:              # holds a Method object describing guidelines followed in generating the evidence assessment in this Evidence Line
-      type: Method
-      methodType: PM2
-      name: ClinGen Hearing Loss Expert Panel Specifications to the ACMG/AMP Variant Interpretation Guidelines
-      reportedIn:             # a document that describes the Method (this is all we are given about this Method in the source data)
-        type: Document
-        urls:
-          - https://clinicalgenome.org/docs/clingen-hearing-loss-expert-panel-specifications-to-the-acmg-amp-variant-interpretation-guidelines/
-    contributions:            # holds descriptions of contributions to this Evidence Line
-      - type: Contribution
-        contributor:
-          id: curator001
-          type: Agent
-        activityType:
-          name: evidence evaluation
-        date: '2018-03-11'
-  - id: ex:EvidenceLine002               # an Evidence Line based on functional impact data about the variant from MAVE (https://mavedb.org/)
-    type: EvidenceLine                   # uses the core EvidenceLine class as its type, but validated against the VariantPathogenicityEvidenceLine Profile
-    targetProposition: ex:Proposition001
-    hasEvidenceItems:
-      - id: ex:Statement002              # here the evidence item is another Statement about the functional impact of the variant
-        type: Statement
-        proposition:
-          type: ExperimentalVariantFunctionalImpactProposition
-          subjectVariant: ex:Variant001  # the full representation of the variant subject of this Statement is not included
-          predicate: impactsFunctionOf   # the predicate for this type of Statement is fixed at 'impactsFunctionOf'
-          objectSequenceFeature:         # holds a MappableConcept object that represents the Gene impacted by the variant, using names/codes from existing code systems
-            id: clinvar-gene:9132
-            conceptType: Gene
-            primaryCoding:
-              code: ncbigene:9132
-              system: https://identifiers.org/ncbigene
-              iris:
-                - https://identifiers.org/ncbigene:9132
-            name: KCNQ4
-          experimentalContextQualifier:      # this qualifier is able to take a custom, data provider-defined object to describe the experiment in which the reported impact was determined. A condensed example is shown here, but an real and complete example can be found in the Exp-Var-Func-Impact-Statement-01.yaml test fixtures file.
-            title: KCNQ4 VAMP Seq Expt 001
-            description: Multiplex assessment of KCNQ4 protein variant abundance by massively parallel sequencing
-            phenotypicAssay: flow cytometry
-            modelSystem: immortalized human cells
-            variantLibrarySystem: oligo-directed mutagenic PCR
-            profilingStrategy: barcode sequencing
-            sequencingReadType: single-segment (short read)
-        direction: supports           # indicates that the Statement supports the assessed impact Proposition above (i.e. says that the subject Variant does impact the function of the object Gene)
-        classification:               # summarizes the Statement in terms of a final classification of the variant, using a term familiar in the community of use.
-          primaryCoding:
-            code: abnormal            # indicates the variant version of the gene has abnormal function (consistent with the 'impactsFunctionOf' proposition being 'supported')
-            system: ga4gh-gks-term:experimental-var-func-impact-classification
-        specifiedBy:                  # a Method followed to produce the Statement, which is described by the publication indicated below
-          type: Method
-          methodType:
-            name: variant interpretation guideline
-          reportedIn:
-            type: Document
-            pmid: 29785012
-        hasEvidenceLines:
-          id: EvidenceLine003
-          type: EvidenceLine
-          directionOfEvidenceProvided: supports  # indicates that EvidenceLine003 based on a Functional Impact Study Result 'supports' the Functional Impact Statement
-          specifiedBy:          # a Method followed in assessing the direction and strength of evidence provided by the Functional Impact StudyResult for the Functional Impact Statement
-            type: Method
-            name: MAVE bayesian threshold probability method 001
-            reportedIn:
-              type: Document
-              urls:
-                - "https://mavedb.org/score-sets/urn:mavedb:00000013-a-1"
-          hasEvidenceItems:             # a Study Result that captures the experimental data and scores on which the Functional Impact Statement was based.
-            - id: ex:StudyResult002     # the evidence in this case is data captured in a Functional Impact Study Result
-              type: ExperimentalVariantFunctionalImpactStudyResult
-              focusVariant: ex:Variant001   # the KCNQ4 variant that data are about (a full representation of the variant is not included)
-              functionalImpactScore: 1.29395467005388        # this is the only data item included right now in this StudyResult
-              specifiedBy:
-                type: Method
-                methodType:
-                  name: Experimental protocol
-                reportedIn:
-                  type: Document
-                  pmid: 29785012
-              sourceDataSet:
-                type: DataSet
-                name: variant effect data set
-                license:
-                  primaryCoding:
-                    code: CC0
-                    system: https://spdx.org/licenses/
-                    iris:
-                      - https://spdx.org/licenses/CC0-1.0.html
-                reportedIn:
-                  type: Document
-                  urls:
-                    - "https://mavedb.org/score-sets/urn:mavedb:00000013-a-1"
-    directionOfEvidenceProvided: supports   # indicates that EvidenceLine002 based on a Functional Impact Statement 'supports' the root Pathogenicity Statement
-    strengthOfEvidenceProvided:
-      primaryCoding:
-        code: strong                      # indicates that this line of evidence provides 'strong' support for the variant's Pathogencity
-        system: ACMG Guidelines, 2015
-    evidenceOutcome:
-      primaryCoding:
-        code: PS3_strong
-        system: ACMG Guidelines, 2015
-      name: ACMG 2015 PS3 Supporting Criterion Met
-    specifiedBy:          # holds a Method object describing guidelines followed in assessing the evidence provided by the Functional Impact Statement for the root Pathogenicity Statement
-      type: Method
-      methodType: PS3
-      name: ClinGen Hearing Loss Expert Panel Specifications to the ACMG/AMP Variant Interpretation Guidelines
-      reportedIn:
-        type: Document
-        urls:
-          - https://clinicalgenome.org/docs/clingen-hearing-loss-expert-panel-specifications-to-the-acmg-amp-variant-interpretation-guidelines/
-    contributions:
-      - type: Contribution
-        contributor:
-          id: curator002       # the curator who assessed functional impact statement as evidence for pathogenicity
-          type: Agent
-        activityType:
-          name: evidence evaluation
-        date: '2018-04-03'
-  extensions:      # holds Extension objects which allow data providers to define key-value pairs for capturing additional info not supported by the VA model.
-  - name: clinvarMethodCategory   # here, Extensions are used to report clinvar-specific values that the data provider does not want to lose
-    value: literature only
-  - name: clinvarReviewStatus
-    value: no assertion criteria provided
-  - name: clinvarSubmittedClassification
-    value: Pathogenic
+   id: ex:Statement001
+   type: Statement              # Formal type in the model is 'Statement', but the data aligns with the "Variant Pathogenicity Statement (ACMG 2015)" Community Profile.
+   proposition:                 # a Proposition object captures the possible fact assessed by the Statement, using a subject, predicate, object, qualifier (SPOQ) semantic modeling pattern.
+     id: ex:Proposition001      # the proposition here is that "NM_004700.4:c.803CCT[1] is causal for AD nonsyndromic hearing loss 2A"
+     type: VariantPathogenicityProposition
+     subjectVariant: ex:Variant001    # 'subjectVariant' specializes the VA Core 'subject' attribute. The full representation of the NM_004700.4:c.803CCT[1] KCNQ4 variant is not included.
+     predicate: isCausalFor           # the predicate for this Statement profile is fixed at 'isCausalFor'
+     objectCondition:                 # 'objectCondition' specializes the VA Core 'object' attribute.
+       id: clinvar.trait/939    # this is a MappableConcept object that represents the Condition, using names/codes from existing code systems
+       conceptType: Disease
+       name: Autosomal dominant nonsyndromic hearing loss 2A    # the name for the concept as assigned by the data provider
+       primaryCoding:           # holds a Coding object, where the concept is defined in the 'code' or 'name' field
+         code: C2677637         # the code from the MedGen terminology for AD nonsyndromic hearing loss 2A
+         system: https://www.ncbi.nlm.nih.gov/medgen/
+         iris:
+           - http://identifiers.org/medgen/C2677637
+     penetranceQualifier:       # holds a MappableConcept that reports qualifying penetrance information about the object condition (here, that the statement holds for high penetrance AD hearing loss)
+       primaryCoding:
+         code: high
+         system: ga4gh-gks-term:pathogenicity-penetrance-qualifier   # code system here is a locally defined placeholder, until we formalize terminological standards for use in the VA-Spec
+       name: high
+   direction: supports          # an enumerated string that indicates the Statement 'supports' the Proposition as true
+   strength:                    # holds a MappableConcept reporting that confidence/evidence for this stated support
+     primaryCoding:
+       code: definitive         # the code here is a term based on language used in the ACMG guidelines, as ACMG does not provide a formal code system for this
+       system: ACMG Guidelines, 2015
+   classification:              # holds a MappableConcept reporting the final ACMG classification of the subject variant  to be 'pathogenic'
+     primaryCoding:
+       code: pathogenic         # the code here is a term based on language in the ACMG guidelines, as ACMG does not provide a formal code system for this
+       system: ACMG Guidelines, 2015
+   contributions:               # a list of Contribution objects, each describing how an agent contributed to the Statement
+     - type: Contribution
+       contributor:             # reports who made this contribution
+         id: clinvar.submitter/500139
+         type: Agent
+         name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
+       activityType:            # reports the type of contribution that was made (here an evaluation activity)
+         name: evaluated
+         mappings:
+           - coding:
+               code: cg000011
+               system: https://dataexchange.clinicalgenome.org/codes/
+             relation: exactMatch
+       date: '2015-08-20'       # reports when this contribution was performed
+     - type: Contribution
+       contributor:
+         id: clinvar.submitter/500139
+         type: Agent
+         name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
+       activityType:
+         name: submitted
+         mappings:
+           - coding:
+               code: cg000010
+               system: https://dataexchange.clinicalgenome.org/codes/
+             relation: exactMatch
+       date: '2018-06-12'
+   specifiedBy:                 # holds a Method object describing guidelines followed in generating the knowledge reported in the Statement
+     type: Method
+     name: ClinGen Hearing Loss Expert Panel Specifications to the ACMG/AMP Variant Interpretation Guidelines
+     reportedIn:                # a document that describes the Method
+       type: Document
+       urls:
+         - https://clinicalgenome.org/docs/clingen-hearing-loss-expert-panel-specifications-to-the-acmg-amp-variant-interpretation-guidelines/
+   hasEvidenceLines:            # holds EvidenceLine objects describing how difference types of evidence was interpreted to support the root Statement
+   - id: ex:EvidenceLine001     # an Evidence Line based on cohort allele frequency data from gnomAD (https://gnomad.broadinstitute.org/)
+     type: EvidenceLine         # uses the core EvidenceLine class as its type, but validated against the VariantPathogenicityEvidenceLine Profile
+     targetProposition: ex:Proposition001     # the possible fact against which evidence information is assessed in this EvidenceLine (typically, as here, this is the same proposition as asserted in the root Statement it supports)
+     hasEvidenceItems:          # the information interpreted as evidence in building this Evidence Line
+     - id: ex:StudyResult001    # here, the evidence consists of a single StudyResult, which collects several allele frequency data items about the 1-10120-T-G allele.
+       type: CohortAlleleFrequencyStudyResult
+       name: Overall Cohort Allele Frequency for 1-40819444_40819446-del
+       focusAllele: ex:Variant001  # the KCNQ4 variant that data included in this Result are about (the full representation of the variant is not included)
+       focusAlleleFrequency: 0
+       focusAlleleCount: 0      # three specific data items produced by the analysis are collected in this StudyResult (focus allele frequency, focus allele count, and locus allele count)
+       locusAlleleCount: 34086
+       sourceDataSet:           # the gnomAD dataset from which the data included in this Result were pulled.
+         id: gnomad4.1.0
+         type: DataSet
+         name: gnomAD v4.1.0
+         version: 4.1.0
+       cohort:                  # a description of the cohort within the gnomad dataset interrogated in the analysis (here, the full gnomad population)
+         id: ALL
+         name: Overall
+         type: StudyGroup
+       specifiedBy:             # holds a Method object describing protocols and guidelines followed in generating the data reported in the Study Result
+         type: Method
+         name: gnomAD methods
+         reportedIn:            # a document that describes the Method (this is all we are given about this Method in the source data)
+           type: Document
+           name: gnomAD help documentation
+           urls:
+             - "https://gnomad.broadinstitute.org/help"
+     directionOfEvidenceProvided: supports   # reports that the frequency evidence 'supports' the target proposition (as opposed to disputing it)
+     strengthOfEvidenceProvided:
+       primaryCoding:
+         code: moderate        # reports that this supporting evidence is of 'moderate' strength
+         system: ACMG Guidelines, 2015
+     evidenceOutcome:          # holds a single term summarizing evidence direction and strength assessments, using community-specific vocabulary ...
+       primaryCoding:
+         code: PM2_moderate    # ... here, that the evidence line provides moderate evidence for Pathogenicity, based on the ACMG PM2 criteria
+         system: ACMG Guidelines, 2015
+       name: ACMG 2015 PM2 Moderate Criterion Met
+     specifiedBy:              # holds a Method object describing guidelines followed in generating the evidence assessment in this Evidence Line
+       type: Method
+       methodType: PM2
+       name: ClinGen Hearing Loss Expert Panel Specifications to the ACMG/AMP Variant Interpretation Guidelines
+       reportedIn:             # a document that describes the Method (this is all we are given about this Method in the source data)
+         type: Document
+         urls:
+           - https://clinicalgenome.org/docs/clingen-hearing-loss-expert-panel-specifications-to-the-acmg-amp-variant-interpretation-guidelines/
+     contributions:            # holds descriptions of contributions to this Evidence Line
+       - type: Contribution
+         contributor:
+           id: curator001
+           type: Agent
+         activityType:
+           name: evidence evaluation
+         date: '2018-03-11'
+   - id: ex:EvidenceLine002               # an Evidence Line based on functional impact data about the variant from MAVE (https://mavedb.org/)
+     type: EvidenceLine                   # uses the core EvidenceLine class as its type, but validated against the VariantPathogenicityEvidenceLine Profile
+     targetProposition: ex:Proposition001
+     hasEvidenceItems:
+       - id: ex:Statement002              # here the evidence item is another Statement about the functional impact of the variant
+         type: Statement
+         proposition:
+           type: ExperimentalVariantFunctionalImpactProposition
+           subjectVariant: ex:Variant001  # the full representation of the variant subject of this Statement is not included
+           predicate: impactsFunctionOf   # the predicate for this type of Statement is fixed at 'impactsFunctionOf'
+           objectSequenceFeature:         # holds a MappableConcept object that represents the Gene impacted by the variant, using names/codes from existing code systems
+             id: clinvar-gene:9132
+             conceptType: Gene
+             primaryCoding:
+               code: ncbigene:9132
+               system: https://identifiers.org/ncbigene
+               iris:
+                 - https://identifiers.org/ncbigene:9132
+             name: KCNQ4
+           experimentalContextQualifier:      # this qualifier is able to take a custom, data provider-defined object to describe the experiment in which the reported impact was determined. A condensed example is shown here, but an real and complete example can be found in the Exp-Var-Func-Impact-Statement-01.yaml test fixtures file.
+             title: KCNQ4 VAMP Seq Expt 001
+             description: Multiplex assessment of KCNQ4 protein variant abundance by massively parallel sequencing
+             phenotypicAssay: flow cytometry
+             modelSystem: immortalized human cells
+             variantLibrarySystem: oligo-directed mutagenic PCR
+             profilingStrategy: barcode sequencing
+             sequencingReadType: single-segment (short read)
+         direction: supports           # indicates that the Statement supports the assessed impact Proposition above (i.e. says that the subject Variant does impact the function of the object Gene)
+         classification:               # summarizes the Statement in terms of a final classification of the variant, using a term familiar in the community of use.
+           primaryCoding:
+             code: abnormal            # indicates the variant version of the gene has abnormal function (consistent with the 'impactsFunctionOf' proposition being 'supported')
+             system: ga4gh-gks-term:experimental-var-func-impact-classification
+         specifiedBy:                  # a Method followed to produce the Statement, which is described by the publication indicated below
+           type: Method
+           methodType:
+             name: variant interpretation guideline
+           reportedIn:
+             type: Document
+             pmid: 29785012
+         hasEvidenceLines:
+           id: EvidenceLine003
+           type: EvidenceLine
+           directionOfEvidenceProvided: supports  # indicates that EvidenceLine003 based on a Functional Impact Study Result 'supports' the Functional Impact Statement
+           specifiedBy:          # a Method followed in assessing the direction and strength of evidence provided by the Functional Impact StudyResult for the Functional Impact Statement
+             type: Method
+             name: MAVE bayesian threshold probability method 001
+             reportedIn:
+               type: Document
+               urls:
+                 - "https://mavedb.org/score-sets/urn:mavedb:00000013-a-1"
+           hasEvidenceItems:             # a Study Result that captures the experimental data and scores on which the Functional Impact Statement was based.
+             - id: ex:StudyResult002     # the evidence in this case is data captured in a Functional Impact Study Result
+               type: ExperimentalVariantFunctionalImpactStudyResult
+               focusVariant: ex:Variant001   # the KCNQ4 variant that data are about (a full representation of the variant is not included)
+               functionalImpactScore: 1.29395467005388        # this is the only data item included right now in this StudyResult
+               specifiedBy:
+                 type: Method
+                 methodType:
+                   name: Experimental protocol
+                 reportedIn:
+                   type: Document
+                   pmid: 29785012
+               sourceDataSet:
+                 type: DataSet
+                 name: variant effect data set
+                 license:
+                   primaryCoding:
+                     code: CC0
+                     system: https://spdx.org/licenses/
+                     iris:
+                       - https://spdx.org/licenses/CC0-1.0.html
+                 reportedIn:
+                   type: Document
+                   urls:
+                     - "https://mavedb.org/score-sets/urn:mavedb:00000013-a-1"
+     directionOfEvidenceProvided: supports   # indicates that EvidenceLine002 based on a Functional Impact Statement 'supports' the root Pathogenicity Statement
+     strengthOfEvidenceProvided:
+       primaryCoding:
+         code: strong                      # indicates that this line of evidence provides 'strong' support for the variant's Pathogencity
+         system: ACMG Guidelines, 2015
+     evidenceOutcome:
+       primaryCoding:
+         code: PS3_strong
+         system: ACMG Guidelines, 2015
+       name: ACMG 2015 PS3 Supporting Criterion Met
+     specifiedBy:          # holds a Method object describing guidelines followed in assessing the evidence provided by the Functional Impact Statement for the root Pathogenicity Statement
+       type: Method
+       methodType: PS3
+       name: ClinGen Hearing Loss Expert Panel Specifications to the ACMG/AMP Variant Interpretation Guidelines
+       reportedIn:
+         type: Document
+         urls:
+           - https://clinicalgenome.org/docs/clingen-hearing-loss-expert-panel-specifications-to-the-acmg-amp-variant-interpretation-guidelines/
+     contributions:
+       - type: Contribution
+         contributor:
+           id: curator002       # the curator who assessed functional impact statement as evidence for pathogenicity
+           type: Agent
+         activityType:
+           name: evidence evaluation
+         date: '2018-04-03'
+   extensions:      # holds Extension objects which allow data providers to define key-value pairs for capturing additional info not supported by the VA model.
+   - name: clinvarMethodCategory   # here, Extensions are used to report clinvar-specific values that the data provider does not want to lose
+     value: literature only
+   - name: clinvarReviewStatus
+     value: no assertion criteria provided
+   - name: clinvarSubmittedClassification
+     value: Pathogenic
 
 ------
 

--- a/docs/source/examples/acmg-variant-pathogenicity-statement.rst
+++ b/docs/source/examples/acmg-variant-pathogenicity-statement.rst
@@ -12,59 +12,57 @@ ACMG Variant Pathogenicity Statement Example
 
 **Data**:
 
-.. note:: Comments in the example below will be easier to view in the |pathogenicity_statement_example_source_yaml|, which affords the option of a wider browser window.
+.. annotated-code-block:: yaml
 
-.. code-block:: yaml
-
- SCV000778434.1:
-  id: SCV000778434.1
-  type: Statement              # Formal type in the model is 'Statement', but the data aligns with the "Variant Pathogenicity Statement (ACMG 2015)" Community Profile.
-  proposition:                 # a Proposition object captures the possible fact assessed by the Statement, using a subject, predicate, object, qualifier (SPOQ) semantic modeling pattern.
-    id: ex:Proposition001      # the proposition here is that "NM_004700.4:c.803CCT[1] is causal for AD nonsyndromic hearing loss 2A"
-    type: VariantPathogenicityProposition
-    subjectVariant: clinvar/208366    # 'subjectVariant' specializes the VA Core 'subject' attribute, and holds a CatVRS 'Categorical Variant' whose full representation is not shown here.
-    predicate: isCausalFor     # the predicate for this Statement profile is fixed at 'isCausalFor'
-    objectCondition:           # 'objectCondition' specializes the VA Core 'object' attribute.
-      id: clinvar.trait/939    # this is a MappableConcept object that represents the Condition, using names/codes from existing code systems
-      conceptType: Disease
-      name: Autosomal dominant nonsyndromic hearing loss 2A    # the name for the concept as assigned by the data provider
-      primaryCoding:           # holds a Coding object, where the concept is defined in the 'code' or 'name' field
-        code: C2677637         # the code from the MedGen terminology for AD nonsyndromic hearing loss 2A
-        system: https://www.ncbi.nlm.nih.gov/medgen/
-        iris:
-          - http://identifiers.org/medgen/C2677637
-    penetranceQualifier:       # holds a MappableConcept that reports qualifying penetrance information about the object condition (here, that the statement holds for high penetrance AD hearing loss)
+  SCV000778434.1:
+    id: SCV000778434.1
+    type: Statement              # Formal type in the model is 'Statement', but the data aligns with the "Variant Pathogenicity Statement (ACMG 2015)" Community Profile.
+    proposition:                 # a Proposition object captures the possible fact assessed by the Statement, using a subject, predicate, object, qualifier (SPOQ) semantic modeling pattern.
+      id: ex:Proposition001      # the proposition here is that "NM_004700.4:c.803CCT[1] is causal for AD nonsyndromic hearing loss 2A"
+      type: VariantPathogenicityProposition
+      subjectVariant: clinvar/208366    # 'subjectVariant' specializes the VA Core 'subject' attribute, and holds a CatVRS 'Categorical Variant' whose full representation is not shown here.
+      predicate: isCausalFor     # the predicate for this Statement profile is fixed at 'isCausalFor'
+      objectCondition:           # 'objectCondition' specializes the VA Core 'object' attribute.
+        id: clinvar.trait/939    # this is a MappableConcept object that represents the Condition, using names/codes from existing code systems
+        conceptType: Disease
+        name: Autosomal dominant nonsyndromic hearing loss 2A    # the name for the concept as assigned by the data provider
+        primaryCoding:           # holds a Coding object, where the concept is defined in the 'code' or 'name' field
+          code: C2677637         # the code from the MedGen terminology for AD nonsyndromic hearing loss 2A
+          system: https://www.ncbi.nlm.nih.gov/medgen/
+          iris:
+            - http://identifiers.org/medgen/C2677637
+      penetranceQualifier:       # holds a MappableConcept that reports qualifying penetrance information about the object condition (here, that the statement holds for high penetrance AD hearing loss)
+        primaryCoding:
+          code: high
+          system: ga4gh-gks-term:pathogenicity-penetrance-qualifier   # code system here is a locally defined placeholder, until we formalize terminological standards for use in the VA-Spec
+        name: high
+    direction: supports          # an enumerated string that indicates the Statement 'supports' the Proposition as true
+    strength:                    # holds a MappableConcept reporting that confidence/evidence for this stated support
       primaryCoding:
-        code: high
-        system: ga4gh-gks-term:pathogenicity-penetrance-qualifier   # code system here is a locally defined placeholder, until we formalize terminological standards for use in the VA-Spec
-      name: high
-  direction: supports          # an enumerated string that indicates the Statement 'supports' the Proposition as true
-  strength:                    # holds a MappableConcept reporting that confidence/evidence for this stated support
-    primaryCoding:
-      code: definitive         # the code here is a term based on language used in the ACMG guidelines, as ACMG does not provide a formal code system for this
-      system: ACMG Guidelines, 2015
-  classification:              # holds a MappableConcept reporting the final ACMG classification of the subject variant  to be 'pathogenic'
-    primaryCoding:
-      code: pathogenic         # the code here is a term based on language in the ACMG guidelines, as ACMG does not provide a formal code system for this
-      system: ACMG Guidelines, 2015
-  contributions:               # a list of Contribution objects, each describing how an agent contributed to the Statement
-    - type: Contribution
-      contributor:             # reports who made this contribution
-        id: clinvar.submitter/500139
-        type: Agent
-        name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
-      activityType: evaluated  # reports the type of contribution that was made (here an evaluation activity)
-      date: '2015-08-20'       # reports when this contribution was performed
-    - type: Contribution
-      contributor:
-        id: clinvar.submitter/500139
-        type: Agent
-        name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
-      activityType: submitted
-      date: '2018-06-12'
-  specifiedBy:                 # holds a Method object describing guidelines followed in generating the knowledge reported in the Statement
-    type: Method
-    reportedIn:                # a document that describes the Method (this is all we are given about this Method in the source data)
-      type: Document
-      pmid: 25741868
-      name: ACMG Guidelines, 2015
+        code: definitive         # the code here is a term based on language used in the ACMG guidelines, as ACMG does not provide a formal code system for this
+        system: ACMG Guidelines, 2015
+    classification:              # holds a MappableConcept reporting the final ACMG classification of the subject variant  to be 'pathogenic'
+      primaryCoding:
+        code: pathogenic         # the code here is a term based on language in the ACMG guidelines, as ACMG does not provide a formal code system for this
+        system: ACMG Guidelines, 2015
+    contributions:               # a list of Contribution objects, each describing how an agent contributed to the Statement
+      - type: Contribution
+        contributor:             # reports who made this contribution
+          id: clinvar.submitter/500139
+          type: Agent
+          name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
+        activityType: evaluated  # reports the type of contribution that was made (here an evaluation activity)
+        date: '2015-08-20'       # reports when this contribution was performed
+      - type: Contribution
+        contributor:
+          id: clinvar.submitter/500139
+          type: Agent
+          name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
+        activityType: submitted
+        date: '2018-06-12'
+    specifiedBy:                 # holds a Method object describing guidelines followed in generating the knowledge reported in the Statement
+      type: Method
+      reportedIn:                # a document that describes the Method (this is all we are given about this Method in the source data)
+        type: Document
+        pmid: 25741868
+        name: ACMG Guidelines, 2015

--- a/docs/source/examples/custom-variant-pathogenicity-statement.rst
+++ b/docs/source/examples/custom-variant-pathogenicity-statement.rst
@@ -18,9 +18,7 @@ Custom Variant Pathogenicity Statement Example
 
 **Data**:
 
-.. note:: Comments in the example below will be easier to view in the |custom_pathogenicity_statement_example_source_yaml|, which affords the option of a wider browser window.
-
-.. code-block:: yaml
+.. annotated-code-block:: yaml
 
  SCV000778434.1:
   id: SCV000778434.1

--- a/docs/source/examples/custom-variant-pathogenicity-statement.rst
+++ b/docs/source/examples/custom-variant-pathogenicity-statement.rst
@@ -20,56 +20,56 @@ Custom Variant Pathogenicity Statement Example
 
 .. annotated-code-block:: yaml
 
- SCV000778434.1:
-  id: SCV000778434.1
-  type: Statement
-  proposition:                 # a Proposition object captures the possible fact assessed by the Statement, using a subject, predicate, object, qualifier (SPOQ) semantic modeling pattern.
-    id: ex:Proposition001      # the proposition here is that "NM_004700.4:c.803CCT[1] is causal for AD nonsyndromic hearing loss 2A"
-    type: VariantPathogenicityProposition
-    subjectVariant: clinvar/208366    # 'subjectVariant' specializes the VA Core 'subject' attribute, and holds a CatVRS 'Categorical Variant' whose full representation is not shown here.
-    predicate: isCausalFor     # the predicate for this Statement profile is fixed at 'isCausalFor'
-    objectCondition:           # 'objectCondition' specializes the VA Core 'object' attribute.
-      id: clinvar.trait/939    # this is a MappableConcept object that represents the Condition, using names/codes from existing code systems
-      conceptType: Disease
-      name: Autosomal dominant nonsyndromic hearing loss 2A    # the name for the concept as assigned by the data provider
-      primaryCoding:           # holds a Coding object, where the concept is defined in the 'code' or 'name' field
-        code: C2677637         # the code from the MedGen terminology for AD nonsyndromic hearing loss 2A
-        system: https://www.ncbi.nlm.nih.gov/medgen/
-        iris:
-          - http://identifiers.org/medgen/C2677637
-    penetranceQualifier:       # holds a MappableConcept that reports qualifying penetrance information about the object condition (here, that the statement holds for high penetrance AD hearing loss)
-      primaryCoding:
-        code: high
-        system: ga4gh-gks-term:pathogenicity-penetrance-qualifier   # code system here is a locally defined placeholder, until we formalize terminological standards for use in the VA-Spec
-      name: high
-  direction: supports          # an enumerated string that indicates the Statement 'supports' the Proposition as true
-  strength:                    # holds a MappableConcept reporting that confidence/evidence for this stated support
-    primaryCoding:
-      code: established        # the code here based on a term used in the implementers preferred guidelines or application (as opposed to ACMG terminological conventions)
-      system: Implementer System 1
-  classification:              # holds a MappableConcept reporting the final classification of the subject variant to be 'disease-causing'
-    primaryCoding:
-      code: disease-causing    # the code here based on a term used in the implementers preferred guidelines or application (as opposed to ACMG terminological conventions)
-      system: ACMG Guidelines, 2015
-  contributions:               # a list of Contribution objects, each describing how an agent contributed to the Statement
-    - type: Contribution
-      contributor:             # reports who made this contribution
-        id: clinvar.submitter/500139
-        type: Agent
-        name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
-      activityType:            # reports the type of contribution that was made (here an evaluation activity)
-        name: evaluated
-      date: '2015-08-20'       # reports when this contribution was performed
-    - type: Contribution
-      contributor:
-        id: clinvar.submitter/500139
-        type: Agent
-        name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
-      activityType:
-        name: submitted
-      date: '2018-06-12'
-  specifiedBy:                 # holds a Method object describing the implementers guidelines and terminology for recording the knowledge reported in the Statement
-    type: Method
-    reportedIn:                # a document that describes the Method (this is all we are given about this Method in the source data)
-      type: Document
-      name: Alternate Guidelines and Terminology for Variant Pathogenicity Classification
+   SCV000778434.1:
+     id: SCV000778434.1
+     type: Statement
+     proposition:                 # a Proposition object captures the possible fact assessed by the Statement, using a subject, predicate, object, qualifier (SPOQ) semantic modeling pattern.
+       id: ex:Proposition001      # the proposition here is that "NM_004700.4:c.803CCT[1] is causal for AD nonsyndromic hearing loss 2A"
+       type: VariantPathogenicityProposition
+       subjectVariant: clinvar/208366    # 'subjectVariant' specializes the VA Core 'subject' attribute, and holds a CatVRS 'Categorical Variant' whose full representation is not shown here.
+       predicate: isCausalFor     # the predicate for this Statement profile is fixed at 'isCausalFor'
+       objectCondition:           # 'objectCondition' specializes the VA Core 'object' attribute.
+         id: clinvar.trait/939    # this is a MappableConcept object that represents the Condition, using names/codes from existing code systems
+         conceptType: Disease
+         name: Autosomal dominant nonsyndromic hearing loss 2A    # the name for the concept as assigned by the data provider
+         primaryCoding:           # holds a Coding object, where the concept is defined in the 'code' or 'name' field
+           code: C2677637         # the code from the MedGen terminology for AD nonsyndromic hearing loss 2A
+           system: https://www.ncbi.nlm.nih.gov/medgen/
+           iris:
+             - http://identifiers.org/medgen/C2677637
+       penetranceQualifier:       # holds a MappableConcept that reports qualifying penetrance information about the object condition (here, that the statement holds for high penetrance AD hearing loss)
+         primaryCoding:
+           code: high
+           system: ga4gh-gks-term:pathogenicity-penetrance-qualifier   # code system here is a locally defined placeholder, until we formalize terminological standards for use in the VA-Spec
+         name: high
+     direction: supports          # an enumerated string that indicates the Statement 'supports' the Proposition as true
+     strength:                    # holds a MappableConcept reporting that confidence/evidence for this stated support
+       primaryCoding:
+         code: established        # the code here based on a term used in the implementers preferred guidelines or application (as opposed to ACMG terminological conventions)
+         system: Implementer System 1
+     classification:              # holds a MappableConcept reporting the final classification of the subject variant to be 'disease-causing'
+       primaryCoding:
+         code: disease-causing    # the code here based on a term used in the implementers preferred guidelines or application (as opposed to ACMG terminological conventions)
+         system: ACMG Guidelines, 2015
+     contributions:               # a list of Contribution objects, each describing how an agent contributed to the Statement
+       - type: Contribution
+         contributor:             # reports who made this contribution
+           id: clinvar.submitter/500139
+           type: Agent
+           name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
+         activityType:            # reports the type of contribution that was made (here an evaluation activity)
+           name: evaluated
+         date: '2015-08-20'       # reports when this contribution was performed
+       - type: Contribution
+         contributor:
+           id: clinvar.submitter/500139
+           type: Agent
+           name: ClinVar Staff, National Center for Biotechnology Information (NCBI)
+         activityType:
+           name: submitted
+         date: '2018-06-12'
+     specifiedBy:                 # holds a Method object describing the implementers guidelines and terminology for recording the knowledge reported in the Statement
+       type: Method
+       reportedIn:                # a document that describes the Method (this is all we are given about this Method in the source data)
+         type: Document
+         name: Alternate Guidelines and Terminology for Variant Pathogenicity Classification


### PR DESCRIPTION
(you can take or leave this one, it came from an "I wonder if this is possible/how to do it" moment on my part)

I find the "examples" pages pretty hard to read. Each annotation is one long line, and you have to scroll well outside of the viewport to read an invididual note. I guess you could just go click the link to read the source YAML directly, but you lose the benefits of syntax highlighting (and you're still reading single, long lines -- text wrap was invented for a reason!)

<img width="790" height="621" alt="Screenshot 2026-02-04 at 4 45 46 PM" src="https://github.com/user-attachments/assets/a5ab7060-3526-4eaf-95ae-e9791b882a77" />

There's a material-mkdocs [plugin](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-annotations) that adds little annotation tooltips which make this information more digestible, but there's no such equivalent for Sphinx as far as I can tell. So, I had ChatGPT make a very simple one. 

Basically, for a code block that you want tooltipped, you use an `annotated-code-block` instead, and it converts *all* trailing comments into tooltips. See an example [here](https://va-ga4gh--384.org.readthedocs.build/en/384/examples/acmg-variant-pathogenicity-statement.html).

<img width="778" height="539" alt="Screenshot 2025-12-31 at 12 46 06 PM" src="https://github.com/user-attachments/assets/6113d8f4-9d20-432a-8209-5ba9606ac9d9" />
<img width="781" height="501" alt="Screenshot 2025-12-31 at 12 46 02 PM" src="https://github.com/user-attachments/assets/e44b18cd-7133-431f-b43a-4caec1ef6c9b" />

There are some limitations, which I've noted in the extension module, but for these specific pages I think it works pretty well.

ALSO
* Fixed YAML indentation in the examples, there was one column missing a second space
* Autoformat `docs/source/conf.py` for readability