### PR TITLE
docs: auto-update copyright year

### DIFF
--- a/.requirements.txt
+++ b/.requirements.txt
@@ -1,6 +1,6 @@
 pytest
-sphinx ~= 7.2
-sphinx-rtd-theme ~= 1.3
+sphinx ~= 8.1.3
+sphinx-rtd-theme ~= 3.0.2
 pyyaml
 ga4gh.gks.metaschema==0.3.2
 jsonschema

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -101,7 +101,7 @@ print("RTD env:", {
 })
 
 project = 'GA4GH Variant Annotation Specification'
-copyright = '2024, GA4GH VA Contributors'
+copyright = '2024-%Y, GA4GH VA Contributors'
 author = 'Committers'
 master_doc = 'index'
 # get the release from the git tag if available, otherwise use the branch name

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,3 +1,3 @@
-sphinx ~= 7.2
 jinja2 == 3.1.6
-sphinx-rtd-theme == 1.3.0
+sphinx ~= 8.1.3
+sphinx-rtd-theme ~= 3.0.2


### PR DESCRIPTION
mirror of https://github.com/ga4gh/vrs/pull/673

Sphinx 8.1 introduces support for `%Y` as a way to auto-update the copyright year range, if that's something we care about