### PR TITLE
Added imported concepts to readthedocs

### DIFF
--- a/docs/source/core-information-model/domain-entities.rst
+++ b/docs/source/core-information-model/domain-entities.rst
@@ -65,6 +65,37 @@ To represent these diverse types of variation, the VA-Spec imports two complemen
   - A |discrete_allele| as a VRS object
   - A |canonical_allele| as a Cat-VRS object
 
+.. _MolecularVariation:
+
+Molecular Variation
+@@@@@@@@@@@@@@@@@@@
+
+.. include:: ../def/vrs/MolecularVariation.rst
+
+Text about Molecular Variation here. I just copied what was in https://github.com/ga4gh/vrs/blob/v2/docs/source/concepts/MolecularVariation/index.rst?plain=1 for imports in the cat-vrs docs
+
+**Subclasses**
+
+.. toctree::
+   :titlesonly:
+
+   Allele
+   Adjacency
+   CisPhasedBlock
+   Terminus
+   DerivativeMolecule
+
+I added an imported folder and added Allele.rst, as copied from the VRS documentation there, along with cat-vrs' imported/index.rst. I'm not sure why the toc tree isn't showing Allele though... I thought that toctree just needed the files in other folders to show. hrm.
+
+.. _CategoricalVariant:
+
+Categorical Variant
+@@@@@@@@@@@@@@@@@@@
+
+.. include:: ../def/cat-vrs/CategoricalVariant.rst
+
+Text about Categorical Variants here
+
 .. _Condition:
 
 Condition

--- a/docs/source/core-information-model/imported/Allele.rst
+++ b/docs/source/core-information-model/imported/Allele.rst
@@ -1,0 +1,80 @@
+.. _Allele:
+
+Allele
+!!!!!!
+
+The allele class is used for representing contiguous changes on a reference sequence. This class covers the most
+commonly described forms of variation, including all "small" variants such as SNVs and indels that are also representable
+in other contemporary genomic variant formats, such as SPDI, HGVS, and VCF.
+
+Definition and Information Model
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+.. include::  ../../def/vrs/Allele.rst
+
+Example
+@@@@@@@
+
+.. code-block:: json
+
+    {
+        "id": "ga4gh:VA.Oop4kjdTtKcg1kiZjIJAAR3bp7qi4aNT",
+        "type": "Allele",
+        "expressions": [
+            {
+                "syntax": "spdi",
+                "value": "NC_000001.11:40819438:CTCCTCCT:CTCCTCCTCCT"
+            }
+        ],
+        "location": {
+            "type": "SequenceLocation",
+            "sequenceReference": {
+                "refgetAccession": "SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",
+                "residueAlphabet": "na",
+                "id": "NC_000001.11"
+            },
+            "start": 40819438,
+            "end": 40819446
+        },
+        "state": {
+            "type": "ReferenceLengthExpression",
+            "length": 11,
+            "repeatSubunitLength": 3
+        }
+    }
+
+Implementation Guidance
+@@@@@@@@@@@@@@@@@@@@@@@
+
+Sequence Location Coordinates
+#############################
+
+The *location* property of the allele will almost always have *start* and *end* coordinates that are specified using
+integers (not :ref:`Range`). There are some situations, such as the detection of deleted sequence by microarray, where it may
+be appropriate to represent the variant as an Allele; however, other classes for representing such findings should also be
+considered (e.g. :ref:`CopyNumberCount`).
+
+Normalization
+#############
+
+The ``Allele`` also includes conventions for variant normalization (see :ref:`allele-normalization`) that allows for compact and
+uniform representation of variants.
+
+.. admonition:: New in v2
+
+    In VRS v1.x, normalization included methods for full justification of variants, as derived from the NCBI `VOCA`_ algorithm.
+    In v2, this has been extended to include reference length encoding (see :ref:`ReferenceLengthExpression`), to
+    accommodate compressed representation of variants that occur in large repetitive regions.
+
+    For alleles in small repeating regions, it may be convenient to also use the *ReferenceLengthExpression.sequence* attribute
+    to represent the sequence state explicitly alongside the reference encoding.
+
+.. _VOCA: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7523648/
+
+Expressions
+###########
+
+.. admonition:: New in v2
+
+    The v2 :ref:`Variation` classes now support :ref:`Expression`. This is a convenient mechanism for annotating Alleles using
+    string syntaxes following the conventions other variant standards (e.g. HGVS, SPDI) and resources (e.g. ClinVar, gnomAD).

--- a/docs/source/core-information-model/imported/index.rst
+++ b/docs/source/core-information-model/imported/index.rst
@@ -1,0 +1,44 @@
+.. _imported:
+
+Imported Data Types & Classes
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+
+The following data types classes are used by Cat-VRS but maintained by either the VRS subgroup
+or across the GKS Work Stream as core data classes.
+
+VRS
+!!!
+
+.. toctree::
+   :titlesonly:
+
+   Variation
+   Allele
+   CopyNumberCount
+   CopyNumberChange
+   Location
+   SequenceExpression
+   SequenceLocation
+   SequenceReference
+   LiteralSequenceExpression
+   ReferenceLengthExpression
+   LengthExpression
+   Expression
+   Range
+   Terminus
+
+GKS Core
+!!!!!!!!
+
+.. toctree::
+   :titlesonly:
+
+   Entity
+   Element
+   Extension
+   MappableConcept
+   ConceptMapping
+   ConceptSet
+   Coding
+   code
+   iriReference

--- a/docs/source/core-information-model/index.rst
+++ b/docs/source/core-information-model/index.rst
@@ -25,3 +25,4 @@ Links below (or menu to the left) provide detailed information about the attribu
    elements/index
    data-types
    domain-entities
+   imported/index


### PR DESCRIPTION
Even though the def/ folders get populated via the meta schema processor from git submodules, the actual rst files that readthedocs renders need to be manually generated for each site.