### PR TITLE
feat: update submodules for cat-vrs/vrs/gks-core

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/cat-vrs"]
 	path = submodules/cat-vrs
 	url = https://github.com/ga4gh/cat-vrs.git
-	branch = 1.0
+	branch = v1

--- a/schema/va-spec/aac-2017/json/AmpAscoCapEvidenceLine
+++ b/schema/va-spec/aac-2017/json/AmpAscoCapEvidenceLine
@@ -28,7 +28,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
                         },
                         {
                            "properties": {

--- a/schema/va-spec/aac-2017/json/DiagnosticEvidenceLine
+++ b/schema/va-spec/aac-2017/json/DiagnosticEvidenceLine
@@ -26,7 +26,7 @@
             ]
          },
          {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
          }
       ]
    }

--- a/schema/va-spec/aac-2017/json/PrognosticEvidenceLine
+++ b/schema/va-spec/aac-2017/json/PrognosticEvidenceLine
@@ -26,7 +26,7 @@
             ]
          },
          {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
          }
       ]
    }

--- a/schema/va-spec/aac-2017/json/TherapeuticEvidenceLine
+++ b/schema/va-spec/aac-2017/json/TherapeuticEvidenceLine
@@ -26,7 +26,7 @@
             ]
          },
          {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
          }
       ]
    }

--- a/schema/va-spec/aac-2017/json/VariantClinicalSignificanceStatement
+++ b/schema/va-spec/aac-2017/json/VariantClinicalSignificanceStatement
@@ -19,7 +19,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
                         },
                         {
                            "properties": {
@@ -44,7 +44,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
                         },
                         {
                            "properties": {

--- a/schema/va-spec/aac-2017/profile-source.yaml
+++ b/schema/va-spec/aac-2017/profile-source.yaml
@@ -26,7 +26,7 @@ $defs:
             properties:
               primaryCoding:
                 allOf:
-                  - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                  - $ref: "/ga4gh/schema/gks-core/1.1.0/json/Coding"
                   - properties:
                       code:
                         enum: [A, B, C, D]
@@ -47,7 +47,7 @@ $defs:
               targetProposition:
                 $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPrognosticProposition"
             required: [targetProposition]
-        - $ref: "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+        - $ref: "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
 
   DiagnosticEvidenceLine:
     maturity: draft
@@ -62,7 +62,7 @@ $defs:
               targetProposition:
                 $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantDiagnosticProposition"
             required: [targetProposition]
-        - $ref: "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+        - $ref: "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
 
   TherapeuticEvidenceLine:
     maturity: draft
@@ -77,7 +77,7 @@ $defs:
               targetProposition:
                 $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantTherapeuticResponseProposition"
             required: [targetProposition]
-        - $ref: "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+        - $ref: "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
 
   VariantClinicalSignificanceStatement:
     maturity: draft
@@ -98,7 +98,7 @@ $defs:
             properties:
               primaryCoding:
                 allOf:
-                  - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                  - $ref: "/ga4gh/schema/gks-core/1.1.0/json/Coding"
                   - properties:
                       code:
                         enum:
@@ -113,7 +113,7 @@ $defs:
             properties:
               primaryCoding:
                 allOf:
-                  - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                  - $ref: "/ga4gh/schema/gks-core/1.1.0/json/Coding"
                   - properties:
                       code:
                         enum:

--- a/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
+++ b/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
@@ -39,7 +39,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
                         },
                         {
                            "oneOf": [

--- a/schema/va-spec/acmg-2015/profile-source.yaml
+++ b/schema/va-spec/acmg-2015/profile-source.yaml
@@ -55,7 +55,7 @@ $defs:
           properties:
             primaryCoding:
               allOf:
-                - $ref: "/ga4gh/schema/gks-core/1.0.0/json/Coding"
+                - $ref: "/ga4gh/schema/gks-core/1.1.0/json/Coding"
                 - oneOf:
                   - properties:
                       code:

--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -7,7 +7,7 @@ imports:
   gks-core: ../../gks-core/gks-core-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.0.0/json/
+  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
 
 $defs:
   # Condition data structure for consolidating the different forms of conditions, individual vs co-occurring traits

--- a/schema/va-spec/base/json/Agent
+++ b/schema/va-spec/base/json/Agent
@@ -27,7 +27,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
+++ b/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -42,7 +42,7 @@
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "A specification that describes all or part of the process that led to creation of the Information Entity",
@@ -66,7 +66,7 @@
                   "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ]
          },
@@ -101,7 +101,7 @@
       "focusAllele": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"

--- a/schema/va-spec/base/json/Condition
+++ b/schema/va-spec/base/json/Condition
@@ -10,7 +10,7 @@
          "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet"
       },
       {
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
       }
    ]
 }

--- a/schema/va-spec/base/json/ConditionSet
+++ b/schema/va-spec/base/json/ConditionSet
@@ -14,7 +14,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -28,7 +28,7 @@
                   "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
                }
             ]
          },

--- a/schema/va-spec/base/json/Contribution
+++ b/schema/va-spec/base/json/Contribution
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -54,7 +54,7 @@
       "date": {
          "description": "When the contributing activity was completed.",
          "$comment": "Populate this attribute with the date and time the activity was completed. MUST use ISO8601 format (\"YYYY-MM-DDTHH:MM:SS\"), e.g. \"2024-02-25T09:25:00\". In cases where a date alone is sufficient, the \"THH:MM:SS\" portion of the datetime string MAY be omitted (e.g. \"2024-02-25\").  Specifying a time zone is optional, and SHOULD use the Timezone Offset convention (+/- hours offset from UTC), e.g. \"2024-02-25T09:25:00-5:00\" for the US eastern time zone.",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/datetime"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/datetime"
       }
    },
    "required": [

--- a/schema/va-spec/base/json/DataSet
+++ b/schema/va-spec/base/json/DataSet
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -56,7 +56,7 @@
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "A document in which the the Method is reported."
@@ -64,7 +64,7 @@
       "releaseDate": {
          "description": "Indicates the date a version of a DataSet was formally released.",
          "$comment": "This attribute may apply to version and distribution-level DataSet representations. It refers to when the data set was released, which may be different than the data set was generated.",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/date"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/date"
       },
       "version": {
          "type": "string",
@@ -74,7 +74,7 @@
       "license": {
          "description": "A specific license that dictates legal permissions for how a data set can be used (by whom, where, for what purposes, with what additional requirements, etc.)",
          "$comment": "Where possible, provide a URL pointing to the license or a description of it (e.g. \"https://creativecommons.org/licenses/by/4.0/\"). Otherwise, provide a free-text name or description of the license (e.g. \"CC-BY\").",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/va-spec/base/json/Document
+++ b/schema/va-spec/base/json/Document
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/va-spec/base/json/EvidenceLine
+++ b/schema/va-spec/base/json/EvidenceLine
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -43,7 +43,7 @@
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "A specification that describes all or part of the process that led to creation of the Information Entity",
@@ -67,7 +67,7 @@
                   "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ]
          },
@@ -121,7 +121,7 @@
                   "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ]
          },
@@ -140,7 +140,7 @@
       "strengthOfEvidenceProvided": {
          "description": "The strength of support that an Evidence Line is determined to provide for or against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided value.",
          "$comment": "Values of this attribute can be defined by for a given profile based on domain/application needs, but should be framed in qualitative terms (e.g. 'strong', 'moderate', 'weak'). The 'scoreOfEvidenceProvided' attribute can be used to report quantitative assessments of evidence provided.",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
       },
       "scoreOfEvidenceProvided": {
          "type": "number",
@@ -148,7 +148,7 @@
       },
       "evidenceOutcome": {
          "description": "A term summarizing the overall outcome of the evidence assessment represented by the Evidence Line, in terms of the direction and strength of support it provides for or against the target Proposition.",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -42,7 +42,7 @@
                "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
@@ -68,10 +68,10 @@
       "objectSequenceFeature": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "The sequence feature (typically a gene or gene product) on whose function the impact of the subject variant is reported.",
@@ -81,7 +81,7 @@
          "description": "An assay in which the reported variant functional impact was determined - providing a specific experimental context in which this effect is asserted to hold.",
          "anyOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -54,7 +54,7 @@
                   "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ]
          },
@@ -84,7 +84,7 @@
       "focusVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
@@ -103,7 +103,7 @@
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "The assay that was performed to generate the reported functional impact score.",

--- a/schema/va-spec/base/json/Method
+++ b/schema/va-spec/base/json/Method
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -55,7 +55,7 @@
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "A document in which the the Method is reported."

--- a/schema/va-spec/base/json/Statement
+++ b/schema/va-spec/base/json/Statement
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -43,7 +43,7 @@
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "A specification that describes all or part of the process that led to creation of the Information Entity",
@@ -67,7 +67,7 @@
                   "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ]
          },
@@ -120,7 +120,7 @@
       "strength": {
          "description": "A term used to report the strength of a Proposition's assessment in the direction indicated (i.e. how strongly supported or disputed the Proposition is believed to be).  Implementers may choose to frame a strength assessment in terms of how *confident* an agent is that the Proposition is true or false, or in terms of the *strength of all evidence* they believe supports or disputes it.",
          "$comment": "Statements put forth a Proposition that expresses some possible fact about the world, and may provide an assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated evidence) using 'direction', 'strength', and 'score' attributes. The 'strength' attribute is used to report the strength of this assessment in the direction indicated. Strength can be framed as a *level of confidence* that the Proposition is true or false, or as a *level of evidence* that supports or disputes it. Data creators can define the permissible values for the 'strength' attribute to indicate which of these facets is being assessed (e.g. 'high confidence' vs 'low confidence', or 'strong evidence' vs 'weak evidence') - or they can choose values that don't commit to one or the other if they don't want to make the distinction (e.g. 'high' vs 'medium' vs 'low').",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
       },
       "score": {
          "type": "number",
@@ -131,7 +131,7 @@
       "classification": {
          "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's Proposition, in terms of a classification of its subject.",
          "$comment": "Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice - and can be provided to report of a statement's conclusion in user-friendly terms. For example, in a Statement assessing the proposition that \"BRCA2 c.8023A>G is pathogenic for Breast Cancer\", and reporting a direction of 'supports' and strength of 'likely', the term  'likely pathogenic' from the ACMG Variant Interpretation Guidelines would be used as a subject classification.",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
       },
       "hasEvidenceLines": {
          "type": "array",
@@ -142,7 +142,7 @@
                   "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ]
          },

--- a/schema/va-spec/base/json/StudyGroup
+++ b/schema/va-spec/base/json/StudyGroup
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -53,7 +53,7 @@
       "characteristics": {
          "type": "array",
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
          },
          "ordered": false,
          "description": "A feature or role shared by all members of the StudyGroup, representing a criterion for membership in the group.",

--- a/schema/va-spec/base/json/Therapeutic
+++ b/schema/va-spec/base/json/Therapeutic
@@ -10,7 +10,7 @@
          "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/TherapyGroup"
       },
       {
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
       }
    ]
 }

--- a/schema/va-spec/base/json/TherapyGroup
+++ b/schema/va-spec/base/json/TherapyGroup
@@ -14,7 +14,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -23,7 +23,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
          },
          "description": "A list of therapies that are applied to treat a condition.",
          "minItems": 2

--- a/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
+++ b/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -42,7 +42,7 @@
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ],
          "description": "A specification that describes all or part of the process that led to creation of the Information Entity",
@@ -66,7 +66,7 @@
                   "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
                }
             ]
          },
@@ -104,7 +104,7 @@
                "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"

--- a/schema/va-spec/base/json/VariantClinicalSignificanceProposition
+++ b/schema/va-spec/base/json/VariantClinicalSignificanceProposition
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -42,7 +42,7 @@
                "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -91,7 +91,7 @@
       "objectCondition": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"

--- a/schema/va-spec/base/json/VariantDiagnosticProposition
+++ b/schema/va-spec/base/json/VariantDiagnosticProposition
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -42,7 +42,7 @@
                "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -93,7 +93,7 @@
       "objectCondition": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"

--- a/schema/va-spec/base/json/VariantOncogenicityProposition
+++ b/schema/va-spec/base/json/VariantOncogenicityProposition
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -42,7 +42,7 @@
                "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -91,7 +91,7 @@
       "objectTumorType": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"

--- a/schema/va-spec/base/json/VariantPathogenicityProposition
+++ b/schema/va-spec/base/json/VariantPathogenicityProposition
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -42,7 +42,7 @@
                "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -91,7 +91,7 @@
       "objectCondition": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"
@@ -102,11 +102,11 @@
       },
       "penetranceQualifier": {
          "description": "Reports the penetrance of the pathogenic effect - i.e. the extent to which the variant impact is expressed by individuals carrying it as a measure of the proportion of carriers exhibiting the condition.",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
       },
       "modeOfInheritanceQualifier": {
          "description": "Reports a pattern of inheritance expected for the pathogenic effect of the variant. Consider using terms or codes from community terminologies here - e.g. terms from the 'Mode of inheritance' branch of the Human Phenotype Ontology such as HP:0000006 (autosomal dominant inheritance).",
-         "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/va-spec/base/json/VariantPrognosticProposition
+++ b/schema/va-spec/base/json/VariantPrognosticProposition
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -42,7 +42,7 @@
                "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -93,7 +93,7 @@
       "objectCondition": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"

--- a/schema/va-spec/base/json/VariantTherapeuticResponseProposition
+++ b/schema/va-spec/base/json/VariantTherapeuticResponseProposition
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.0.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -42,7 +42,7 @@
                "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             }
          ]
       },
@@ -93,7 +93,7 @@
       "objectTherapeutic": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Therapeutic"
@@ -105,7 +105,7 @@
       "conditionQualifier": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.0.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"

--- a/schema/va-spec/base/va-core-source.yaml
+++ b/schema/va-spec/base/va-core-source.yaml
@@ -10,7 +10,7 @@ imports:
   gks-core: ../../gks-core/gks-core-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.0.0/json/
+  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
   vrs: /ga4gh/schema/vrs/2.0.1/json/
   cat-vrs: /ga4gh/schema/cat-vrs/1.0.0/json/
 


### PR DESCRIPTION
* change branch from 1.0 to v1

Want to make sure that it's okay that for GKS specs, the `v{major}` branches can reference `v{major}` branches in upstream specs.