### PR TITLE
docs: add README to Modeling subdirectory

### DIFF
--- a/docs/Modeling/README.md
+++ b/docs/Modeling/README.md
@@ -1,0 +1,10 @@
+# Modeling Notes and Proposals
+
+This directory contains historical modeling proposals, examples, sketches, and exploratory notes that were moved from the repository root for organizational consistency.
+
+Most content here is informal and non-normative. These documents may:
+- reflect superseded ideas or earlier iterations,
+- contain partial examples or experimental approaches,
+- provide useful background or design context for current specifications.
+
+Unless explicitly referenced elsewhere in the specification, files in this directory should not be interpreted as current standards or implementation guidance.


### PR DESCRIPTION
The `docs/Modeling` subdirectory was created [here](https://github.com/ga4gh/va-spec/commit/b9a17359eb0d385090422de899025fab92c8a00f) to, as far as I can tell, hold onto some older working examples without throwing them into the trash bin. Having spent some time in the docs recently, I started getting a little confused by these files (they don't show up in the live docs, but they are in the repo, so if you do a search in your IDE they might come up) so I thought a simple README might be helpful to clarify intent, based on @mbrush 's commit message. Please edit as necessary or disregard if unnecessary.

Another solution would be to just delete this subdirectory of course, if it's no longer helpful (it would stay in git history but would be a bit of work to dig up again).