### PR TITLE
ballot-prep: bump schema versions and add required type discriminators

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/cat-vrs"]
 	path = submodules/cat-vrs
 	url = https://github.com/ga4gh/cat-vrs.git
-	branch = v1
+	branch = 1.1.0-ballot.2026-07

--- a/schema/va-spec/aac-2017/def/AmpAscoCapEvidenceLine.rst
+++ b/schema/va-spec/aac-2017/def/AmpAscoCapEvidenceLine.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 Evidence line for AMP/ASCO/CAP
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/aac-2017/def/VariantClinicalSignificanceStatement.rst
+++ b/schema/va-spec/aac-2017/def/VariantClinicalSignificanceStatement.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 A statement reporting a conclusion from a single study about the clinical significance of a variant with respect to a condition, based on interpretation of the study's results.
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/aac-2017/json/AmpAscoCapEvidenceLine
+++ b/schema/va-spec/aac-2017/json/AmpAscoCapEvidenceLine
@@ -1,25 +1,25 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/aac-2017/json/AmpAscoCapEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/AmpAscoCapEvidenceLine",
    "title": "AmpAscoCapEvidenceLine",
    "description": "Evidence line for AMP/ASCO/CAP",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/EvidenceLine"
       },
       {
          "properties": {
             "targetProposition": {
                "oneOf": [
                   {
-                     "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPrognosticProposition"
+                     "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPrognosticProposition"
                   },
                   {
-                     "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantDiagnosticProposition"
+                     "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantDiagnosticProposition"
                   },
                   {
-                     "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantTherapeuticResponseProposition"
+                     "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantTherapeuticResponseProposition"
                   }
                ]
             },
@@ -28,7 +28,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Coding"
                         },
                         {
                            "properties": {

--- a/schema/va-spec/aac-2017/json/DiagnosticEvidenceLine
+++ b/schema/va-spec/aac-2017/json/DiagnosticEvidenceLine
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/aac-2017/json/DiagnosticEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/DiagnosticEvidenceLine",
    "title": "DiagnosticEvidenceLine",
    "description": "Diagnostic evidence line for AMP/ASCO/CAP",
    "maturity": "draft",
@@ -11,12 +11,12 @@
          {
             "allOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/aac-2017/json/AmpAscoCapEvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/AmpAscoCapEvidenceLine"
                },
                {
                   "properties": {
                      "targetProposition": {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantDiagnosticProposition"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantDiagnosticProposition"
                      }
                   },
                   "required": [
@@ -26,7 +26,7 @@
             ]
          },
          {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
          }
       ]
    }

--- a/schema/va-spec/aac-2017/json/PrognosticEvidenceLine
+++ b/schema/va-spec/aac-2017/json/PrognosticEvidenceLine
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/aac-2017/json/PrognosticEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/PrognosticEvidenceLine",
    "title": "PrognosticEvidenceLine",
    "description": "Prognostic evidence line for AMP/ASCO/CAP",
    "maturity": "draft",
@@ -11,12 +11,12 @@
          {
             "allOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/aac-2017/json/AmpAscoCapEvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/AmpAscoCapEvidenceLine"
                },
                {
                   "properties": {
                      "targetProposition": {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPrognosticProposition"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPrognosticProposition"
                      }
                   },
                   "required": [
@@ -26,7 +26,7 @@
             ]
          },
          {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
          }
       ]
    }

--- a/schema/va-spec/aac-2017/json/TherapeuticEvidenceLine
+++ b/schema/va-spec/aac-2017/json/TherapeuticEvidenceLine
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/aac-2017/json/TherapeuticEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/TherapeuticEvidenceLine",
    "title": "TherapeuticEvidenceLine",
    "description": "Therapeutic evidence line for AMP/ASCO/CAP",
    "maturity": "draft",
@@ -11,12 +11,12 @@
          {
             "allOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/aac-2017/json/AmpAscoCapEvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/AmpAscoCapEvidenceLine"
                },
                {
                   "properties": {
                      "targetProposition": {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantTherapeuticResponseProposition"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantTherapeuticResponseProposition"
                      }
                   },
                   "required": [
@@ -26,7 +26,7 @@
             ]
          },
          {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
          }
       ]
    }

--- a/schema/va-spec/aac-2017/json/VariantClinicalSignificanceStatement
+++ b/schema/va-spec/aac-2017/json/VariantClinicalSignificanceStatement
@@ -1,17 +1,17 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/aac-2017/json/VariantClinicalSignificanceStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/VariantClinicalSignificanceStatement",
    "title": "VariantClinicalSignificanceStatement",
    "description": "A statement reporting a conclusion from a single study about the clinical significance of a variant with respect to a condition, based on interpretation of the study's results.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantClinicalSignificanceProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantClinicalSignificanceProposition"
             },
             "strength": {
                "description": "The strength of support that the Statement is determined to provide for or against the Variant Clinical Significance Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP 2017 Guidelines.",
@@ -19,7 +19,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Coding"
                         },
                         {
                            "properties": {
@@ -44,7 +44,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Coding"
                         },
                         {
                            "properties": {
@@ -103,16 +103,16 @@
                "hasEvidenceLines": {
                   "oneOf": [
                      {
-                        "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                        "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/aac-2017/json/DiagnosticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/DiagnosticEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/aac-2017/json/PrognosticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/PrognosticEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/aac-2017/json/TherapeuticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/TherapeuticEvidenceLine"
                      }
                   ]
                },
@@ -189,16 +189,16 @@
                "hasEvidenceLines": {
                   "oneOf": [
                      {
-                        "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                        "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/aac-2017/json/DiagnosticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/DiagnosticEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/aac-2017/json/PrognosticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/PrognosticEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/aac-2017/json/TherapeuticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/json/TherapeuticEvidenceLine"
                      }
                   ]
                },

--- a/schema/va-spec/aac-2017/profile-source.yaml
+++ b/schema/va-spec/aac-2017/profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.1/aac-2017/profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/aac-2017/profile-source.yaml"
 title: AAC 2017 Profiles
 description: >-
   Profiles defined to align with terminology and conventions from the Association for Molecular Pathology (AMP),
@@ -11,20 +11,20 @@ imports:
   gks-core: ../../gks-core/gks-core-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
+  gks.core: /ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/
 
 $defs:
   AmpAscoCapEvidenceLine:
     maturity: draft
     description: Evidence line for AMP/ASCO/CAP
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
+      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/EvidenceLine"
       - properties:
           targetProposition:
             oneOf:
-              - $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPrognosticProposition"
-              - $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantDiagnosticProposition"
-              - $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantTherapeuticResponseProposition"
+              - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPrognosticProposition"
+              - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantDiagnosticProposition"
+              - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantTherapeuticResponseProposition"
           strengthOfEvidenceProvided:
             properties:
               primaryCoding:
@@ -48,9 +48,9 @@ $defs:
           - $ref: "#/$defs/AmpAscoCapEvidenceLine"
           - properties:
               targetProposition:
-                $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPrognosticProposition"
+                $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPrognosticProposition"
             required: [targetProposition]
-        - $ref: "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+        - $ref: "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
 
   DiagnosticEvidenceLine:
     maturity: draft
@@ -63,9 +63,9 @@ $defs:
           - $ref: "#/$defs/AmpAscoCapEvidenceLine"
           - properties:
               targetProposition:
-                $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantDiagnosticProposition"
+                $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantDiagnosticProposition"
             required: [targetProposition]
-        - $ref: "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+        - $ref: "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
 
   TherapeuticEvidenceLine:
     maturity: draft
@@ -78,9 +78,9 @@ $defs:
           - $ref: "#/$defs/AmpAscoCapEvidenceLine"
           - properties:
               targetProposition:
-                $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantTherapeuticResponseProposition"
+                $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantTherapeuticResponseProposition"
             required: [targetProposition]
-        - $ref: "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+        - $ref: "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
 
   VariantClinicalSignificanceStatement:
     maturity: draft
@@ -89,10 +89,10 @@ $defs:
       significance of a variant with respect to a condition, based on interpretation of
       the study's results.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/Statement"
+      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Statement"
       - properties:
           proposition:
-            $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantClinicalSignificanceProposition"
+            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantClinicalSignificanceProposition"
           strength:
             description: >-
               The strength of support that the Statement is determined to provide for or against the Variant Clinical Significance Proposition

--- a/schema/va-spec/acmg-2015/def/VariantPathogenicityEvidenceLine.rst
+++ b/schema/va-spec/acmg-2015/def/VariantPathogenicityEvidenceLine.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 An Evidence Line that describes how a specific type of information was interpreted as evidence for or against a variant's pathogenicity. In the ACMG Framework, evidence is assessed by determining if a specific criterion (e.g. 'PM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the default strength based on the quality and abundance of evidence.
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/acmg-2015/def/VariantPathogenicityStatement.rst
+++ b/schema/va-spec/acmg-2015/def/VariantPathogenicityStatement.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 A Statement describing the role of a variant in causing an inherited condition.
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/acmg-2015/json/VariantPathogenicityEvidenceLine
+++ b/schema/va-spec/acmg-2015/json/VariantPathogenicityEvidenceLine
@@ -1,18 +1,18 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/acmg-2015/json/VariantPathogenicityEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/acmg-2015/json/VariantPathogenicityEvidenceLine",
    "title": "VariantPathogenicityEvidenceLine",
    "description": "An Evidence Line that describes how a specific type of information was interpreted as evidence for or against a variant's pathogenicity. In the ACMG Framework, evidence is assessed by determining if a specific criterion (e.g. 'PM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the default strength based on the quality and abundance of evidence.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/EvidenceLine"
       },
       {
          "properties": {
             "targetProposition": {
                "description": "A Variant Pathogenicity Proposition against which a specific type of evidence was assessed, to determine the strength and direction of support this evidence provides for or against the proposition's validity.",
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPathogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPathogenicityProposition"
             },
             "directionOfEvidenceProvided": {
                "type": "string",
@@ -29,7 +29,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Coding"
                         },
                         {
                            "properties": {

--- a/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
+++ b/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
@@ -1,17 +1,17 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/acmg-2015/json/VariantPathogenicityStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/acmg-2015/json/VariantPathogenicityStatement",
    "title": "VariantPathogenicityStatement",
    "description": "A Statement describing the role of a variant in causing an inherited condition.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPathogenicityProposition",
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPathogenicityProposition",
                "description": "A proposition about the pathogenicity of a variant, the validity of which is assessed and reported by the Statement. A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the level of confidence/evidence supporting this claim."
             },
             "strength": {
@@ -20,7 +20,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Coding"
                         },
                         {
                            "properties": {
@@ -48,7 +48,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Coding"
                         },
                         {
                            "oneOf": [
@@ -98,10 +98,10 @@
                "items": {
                   "anyOf": [
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/acmg-2015/json/VariantPathogenicityEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/acmg-2015/json/VariantPathogenicityEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                        "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                      }
                   ]
                }

--- a/schema/va-spec/acmg-2015/profile-source.yaml
+++ b/schema/va-spec/acmg-2015/profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.1/acmg-2015/profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/acmg-2015/profile-source.yaml"
 title: ACMG 2015 Variant Pathogenicity Profiles
 description: >-
   Profiles defined to align with terminology and conventions from the American College of Medical Genetics
@@ -10,7 +10,7 @@ imports:
   gks-core: ../../gks-core/gks-core-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
+  gks.core: /ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/
 
 $defs:
   # Variant Pathogenicity Statement
@@ -19,10 +19,10 @@ $defs:
     description: >-
       A Statement describing the role of a variant in causing an inherited condition.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/Statement"
+      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Statement"
       - properties:
           proposition:
-            $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPathogenicityProposition"
+            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPathogenicityProposition"
             description: >-
               A proposition about the pathogenicity of a variant, the validity of which is assessed and reported by the Statement.
               A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the
@@ -104,14 +104,14 @@ $defs:
       (e.g. 'PM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the
       default strength based on the quality and abundance of evidence.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
+      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/EvidenceLine"
       - properties:
           targetProposition:
             description: >-
               A Variant Pathogenicity Proposition against which a specific type of evidence was assessed, to
               determine the strength and direction of support this evidence provides for or against the
               proposition's validity.
-            $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPathogenicityProposition"
+            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPathogenicityProposition"
           directionOfEvidenceProvided:
             type: string
             enum: ["supports", "neutral", "disputes"]

--- a/schema/va-spec/base/def/Condition.rst
+++ b/schema/va-spec/base/def/Condition.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 A specialization of MappableConcept representing a single condition (disease, phenotype, or trait). Allowed conceptType values include: Condition, Phenotype, Disease, Trait, Absent.
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/base/def/ConditionSet.rst
+++ b/schema/va-spec/base/def/ConditionSet.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 A specialization of ConceptSet representing a set of conditions (diseases, phenotypes, traits) that occur together or are related, depending on the membership operator. Concepts are restricted to Condition and ConditionSet members.
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/base/def/Therapy.rst
+++ b/schema/va-spec/base/def/Therapy.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 A specialization of MappableConcept representing an individual therapy (drug, procedure, behavioral intervention, etc.). Allowed conceptType values include: Therapy, Absent, Drug, Procedure, Behavioral Intervention.
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/base/def/TherapyGroup.rst
+++ b/schema/va-spec/base/def/TherapyGroup.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 A specialization of ConceptSet representing a group of two or more therapies that are applied in combination to a single patient/subject, or applied individually to a different subset of participants in a research study. Concepts are restricted to Therapy and TherapyGroup members.
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/domain-entities-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/domain-entities-source.yaml"
 title: VA Spec Shared Domain Entity Data Structures
 strict: true
 
@@ -7,7 +7,7 @@ imports:
   gks-core: ../../gks-core/gks-core-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
+  gks.core: /ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/
 
 $defs:
   # Condition data structure for defining single conditions as an extension of MappableConcept

--- a/schema/va-spec/base/json/Agent
+++ b/schema/va-spec/base/json/Agent
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/Agent",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Agent",
    "title": "Agent",
    "type": "object",
    "maturity": "trial use",
@@ -27,7 +27,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
+++ b/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/CohortAlleleFrequencyStudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/CohortAlleleFrequencyStudyResult",
    "title": "CohortAlleleFrequencyStudyResult",
    "maturity": "trial use",
    "type": "object",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -39,10 +39,10 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "A specification that describes all or part of the process that led to creation of the Information Entity",
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -63,10 +63,10 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                }
             ]
          },
@@ -94,17 +94,17 @@
          "default": "CohortAlleleFrequencyStudyResult"
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/DataSet",
          "description": "The dataset from which the CohortAlleleFrequencyStudyResult was reported.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance. If use cases for this arise we can make this attribute take an array of DataSets."
       },
       "focusAllele": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
             }
          ],
          "description": "The Allele for which frequency results are reported.",
@@ -123,7 +123,7 @@
          "description": "The frequency of the focusAllele in the cohort."
       },
       "cohort": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/StudyGroup",
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/StudyGroup",
          "description": "The cohort from which the frequency was derived."
       },
       "subCohortFrequency": {
@@ -131,7 +131,7 @@
          "ordered": false,
          "description": "A list of CohortAlleleFrequency objects describing subcohorts of the cohort currently being described. Subcohorts can be further subdivided into more subcohorts. This enables, for example, the description of different ancestry groups and sexes among those ancestry groups.",
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/CohortAlleleFrequencyStudyResult"
+            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/CohortAlleleFrequencyStudyResult"
          }
       }
    },

--- a/schema/va-spec/base/json/ComputationalVariantFunctionalImpactAnalysisResult
+++ b/schema/va-spec/base/json/ComputationalVariantFunctionalImpactAnalysisResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/ComputationalVariantFunctionalImpactAnalysisResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ComputationalVariantFunctionalImpactAnalysisResult",
    "title": "ComputationalVariantFunctionalImpactAnalysisResult",
    "maturity": "draft",
    "type": "object",
@@ -15,13 +15,13 @@
       "focusVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
             }
          ],
          "description": "The genetic variant for which the in silico analysis was performed."
@@ -29,10 +29,10 @@
       "transcriptVariationContext": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
             }
          ],
          "description": "The transcript in the context of which the in silico analysis was performed."
@@ -44,10 +44,10 @@
       "impactScoreType": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "A descriptor indicating what the score represents (e.g., 'SIFT impact score', 'CADD Phred-scaled impact score')."
@@ -55,10 +55,10 @@
       "categoricalImpact": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "The categorical interpretation derived from the score by the in silico tool (e.g., 'tolerated', 'benign', 'pathogenic')."
@@ -66,10 +66,10 @@
       "impactedFeatureType": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "A descriptor indicating the type of feature for which the focus variant has a predicted impact"
@@ -77,10 +77,10 @@
       "impactedFeature": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "The specific feature for which the focus variant has a predicted impact"
@@ -94,10 +94,10 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "The in silico method or algorithm that was applied to generate the reported score(s)."
@@ -106,12 +106,12 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of this Information Entity."
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/DataSet",
          "description": "The dataset from which the in silico scores were retrieved or derived (e.g., an Ensembl VEP annotation dataset)."
       }
    },

--- a/schema/va-spec/base/json/Condition
+++ b/schema/va-spec/base/json/Condition
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/Condition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Condition",
    "title": "Condition",
    "maturity": "trial use",
    "description": "A specialization of MappableConcept representing a single condition (disease, phenotype, or trait). Allowed conceptType values include: Condition, Phenotype, Disease, Trait, Absent.",
    "$comment": "At present, individual conditions are represented using a MappableConcept that captures a code or name for the condition, along with optional mappings and metadata about the code system. Groups of conditions are represented using the ConditionSet class, which are collections of 2 or more conditions, each represented as a MappableConcept. By convention, cases where no condition is given by the data provider SHOULD be specified using a MappableConcept with a conceptType = \"Absent\". Additionally, either the 'name' or 'primaryCoding' attribute of a MappableConcept must be populated.  The name or code may simple reiterate the conceptType (e.g. 'condition absent'), or report a more specific nature or reason for the absence of a condition (e.g. 'Data Missing in Source', 'Condition Unknown', 'All Mendelian Diseases').",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       },
       {
          "properties": {

--- a/schema/va-spec/base/json/ConditionSet
+++ b/schema/va-spec/base/json/ConditionSet
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ConditionSet",
    "title": "ConditionSet",
    "maturity": "trial use",
    "description": "A specialization of ConceptSet representing a set of conditions (diseases, phenotypes, traits) that occur together or are related, depending on the membership operator. Concepts are restricted to Condition and ConditionSet members.",
    "$comment": "The membershipOperator `OR` should be used only in the specific scenario where a study is done on a cohort of individuals that manifest only one of the conditions in the set. Conclusions about this condition are determined based on an aggregate statistical analysis across all members of this mixed cohort \u2013 because the study does not provide the statistical power to make a conclusion about each condition individually. In such cases, it would be misleading to create separate statements about each condition on its own. Conditions in such groups are typically related in their etiology or manifestation, and patients are pooled to make a single cohort that is large enough support a statistically significant results about this grouping of related conditions.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/ConceptSet"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/ConceptSet"
       },
       {
          "properties": {
@@ -17,10 +17,10 @@
                "items": {
                   "oneOf": [
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Condition"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ConditionSet"
                      }
                   ]
                }

--- a/schema/va-spec/base/json/Contribution
+++ b/schema/va-spec/base/json/Contribution
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/Contribution",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Contribution",
    "title": "Contribution",
    "type": "object",
    "maturity": "trial use",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -44,7 +44,7 @@
          "default": "Contribution"
       },
       "contributor": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Agent",
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Agent",
          "description": "The agent that made the contribution."
       },
       "activityType": {
@@ -54,7 +54,7 @@
       "date": {
          "description": "When the contributing activity was completed.",
          "$comment": "Populate this attribute with the date and time the activity was completed. MUST use ISO8601 format (\"YYYY-MM-DDTHH:MM:SS\"), e.g. \"2024-02-25T09:25:00\". In cases where a date alone is sufficient, the \"THH:MM:SS\" portion of the datetime string MAY be omitted (e.g. \"2024-02-25\").  Specifying a time zone is optional, and SHOULD use the Timezone Offset convention (+/- hours offset from UTC), e.g. \"2024-02-25T09:25:00-5:00\" for the US eastern time zone.",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/datetime"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/datetime"
       }
    },
    "required": [

--- a/schema/va-spec/base/json/DataSet
+++ b/schema/va-spec/base/json/DataSet
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/DataSet",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/DataSet",
    "title": "DataSet",
    "type": "object",
    "maturity": "trial use",
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -53,10 +53,10 @@
       "reportedIn": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Document"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "A document in which the the Method is reported."
@@ -64,7 +64,7 @@
       "releaseDate": {
          "description": "Indicates the date a version of a DataSet was formally released.",
          "$comment": "This attribute may apply to version and distribution-level DataSet representations. It refers to when the data set was released, which may be different than the data set was generated.",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/date"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/date"
       },
       "version": {
          "type": "string",
@@ -74,7 +74,7 @@
       "license": {
          "description": "A specific license that dictates legal permissions for how a data set can be used (by whom, where, for what purposes, with what additional requirements, etc.)",
          "$comment": "Where possible, provide a URL pointing to the license or a description of it (e.g. \"https://creativecommons.org/licenses/by/4.0/\"). Otherwise, provide a free-text name or description of the license (e.g. \"CC-BY\").",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/va-spec/base/json/Document
+++ b/schema/va-spec/base/json/Document
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/Document",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Document",
    "title": "Document",
    "type": "object",
    "maturity": "trial use",
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."

--- a/schema/va-spec/base/json/EvidenceLine
+++ b/schema/va-spec/base/json/EvidenceLine
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/EvidenceLine",
    "title": "EvidenceLine",
    "type": "object",
    "maturity": "trial use",
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -40,10 +40,10 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "A specification that describes all or part of the process that led to creation of the Information Entity",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -64,10 +64,10 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                }
             ]
          },
@@ -84,31 +84,31 @@
          "description": "The possible fact against which evidence items contained in an Evidence Line were collectively evaluated, in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against a target proposition that the variant is pathogenic for a specific disease.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ExperimentalVariantFunctionalImpactProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ExperimentalVariantFunctionalImpactProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/GeneDiseaseValidityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/GeneDiseaseValidityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantClinicalSignificanceProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantClinicalSignificanceProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantDiagnosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantDiagnosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantMolecularConsequenceProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantMolecularConsequenceProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantOncogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantOncogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPathogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPathogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPrognosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPrognosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantTherapeuticResponseProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantTherapeuticResponseProposition"
             }
          ]
       },
@@ -118,16 +118,16 @@
          "items": {
             "anyOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/StudyResult"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/StudyResult"
                },
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Statement"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Statement"
                },
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/EvidenceLine"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                }
             ]
          },
@@ -146,7 +146,7 @@
       "strengthOfEvidenceProvided": {
          "description": "The strength of support that an Evidence Line is determined to provide for or against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided value.",
          "$comment": "Values of this attribute can be defined by for a given profile based on domain/application needs, but should be framed in qualitative terms (e.g. 'strong', 'moderate', 'weak'). The 'scoreOfEvidenceProvided' attribute can be used to report quantitative assessments of evidence provided.",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       },
       "scoreOfEvidenceProvided": {
          "type": "number",
@@ -154,7 +154,7 @@
       },
       "evidenceOutcome": {
          "description": "A term summarizing the overall outcome of the evidence assessment represented by the Evidence Line, in terms of the direction and strength of support it provides for or against the target Proposition.",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/ExperimentalVariantFunctionalImpactProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ExperimentalVariantFunctionalImpactProposition",
    "title": "ExperimentalVariantFunctionalImpactProposition",
    "maturity": "trial use",
    "type": "object",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",
@@ -68,10 +68,10 @@
       "objectSequenceFeature": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "The sequence feature (typically a gene or gene product) on whose function the impact of the subject variant is reported.",
@@ -81,10 +81,10 @@
          "description": "An assay in which the reported variant functional impact was determined - providing a specific experimental context in which this effect is asserted to hold.",
          "anyOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Document"
             },
             {
                "type": "object",

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/ExperimentalVariantFunctionalImpactStudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ExperimentalVariantFunctionalImpactStudyResult",
    "title": "ExperimentalVariantFunctionalImpactStudyResult",
    "maturity": "trial use",
    "type": "object",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -40,7 +40,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -51,10 +51,10 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                }
             ]
          },
@@ -84,10 +84,10 @@
       "focusVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation"
             }
          ],
          "description": "The genetic variant for which a functional impact score is generated.",
@@ -100,17 +100,17 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "The assay that was performed to generate the reported functional impact score.",
          "$comment": "Examples: a specific experimental protocol or data analysis specification that describes how data were generated; an evidence interpretation guideline that describes steps taken to interpret data in making a variant pathogenicity classification; a method for using electron microscopy to image cell membrane proteins. Note that this attribute captures a specific *instance* of a specification or method (e.g. the specific electron microscopy method described in https://doi.org/10.1002/cpz1.1045) - as opposed to reporting a *type* of method applied (e.g. 'Transmission Electron Microscopy')."
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/DataSet",
          "description": "The full data set that provided the reported the functional impact score.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance. If use cases for this arise we can make this attribute take an array of DataSets."
       }

--- a/schema/va-spec/base/json/GeneDiseaseValidityProposition
+++ b/schema/va-spec/base/json/GeneDiseaseValidityProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/GeneDiseaseValidityProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/GeneDiseaseValidityProposition",
    "title": "GeneDiseaseValidityProposition",
    "maturity": "draft",
    "type": "object",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -46,10 +46,10 @@
       "subjectGene": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "The Entity or concept about which the Proposition is made.",
@@ -65,10 +65,10 @@
       "objectCondition": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "An Entity or concept that is related to the subject of a Proposition via its predicate.",
@@ -77,10 +77,10 @@
       "modeOfInheritanceQualifier": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       }

--- a/schema/va-spec/base/json/Method
+++ b/schema/va-spec/base/json/Method
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/Method",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Method",
    "title": "Method",
    "type": "object",
    "maturity": "trial use",
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -52,10 +52,10 @@
       "reportedIn": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Document"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "A document in which the the Method is reported."

--- a/schema/va-spec/base/json/Statement
+++ b/schema/va-spec/base/json/Statement
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/Statement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Statement",
    "title": "Statement",
    "type": "object",
    "maturity": "trial use",
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -40,10 +40,10 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "A specification that describes all or part of the process that led to creation of the Information Entity",
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -64,10 +64,10 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                }
             ]
          },
@@ -85,31 +85,31 @@
          "$comment": "Statements put forth a Proposition that expresses some possible fact about the world, and may provide an assessment of this proposition\u2019s validity (i.e. how likely it is to be true or false based on evaluated evidence). The semantics of the Proposition are explicitly captured using subject, predicate, object, and optional qualifier attributes (SPOQ). An assessment of the Proposition\u2019s validity can optionally be captured using the Statement's direction, strength, and/or score attributes (DS).",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ExperimentalVariantFunctionalImpactProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ExperimentalVariantFunctionalImpactProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/GeneDiseaseValidityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/GeneDiseaseValidityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantClinicalSignificanceProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantClinicalSignificanceProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantDiagnosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantDiagnosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantMolecularConsequenceProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantMolecularConsequenceProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantOncogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantOncogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPathogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPathogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPrognosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPrognosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantTherapeuticResponseProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantTherapeuticResponseProposition"
             }
          ]
       },
@@ -126,7 +126,7 @@
       "strength": {
          "description": "A term used to report the strength of a Proposition's assessment in the direction indicated (i.e. how strongly supported or disputed the Proposition is believed to be).  Implementers may choose to frame a strength assessment in terms of how *confident* an agent is that the Proposition is true or false, or in terms of the *strength of all evidence* they believe supports or disputes it.",
          "$comment": "Statements put forth a Proposition that expresses some possible fact about the world, and may provide an assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated evidence) using 'direction', 'strength', and 'score' attributes. The 'strength' attribute is used to report the strength of this assessment in the direction indicated. Strength can be framed as a *level of confidence* that the Proposition is true or false, or as a *level of evidence* that supports or disputes it. Data creators can define the permissible values for the 'strength' attribute to indicate which of these facets is being assessed (e.g. 'high confidence' vs 'low confidence', or 'strong evidence' vs 'weak evidence') - or they can choose values that don't commit to one or the other if they don't want to make the distinction (e.g. 'high' vs 'medium' vs 'low').",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       },
       "score": {
          "type": "number",
@@ -137,7 +137,7 @@
       "classification": {
          "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's Proposition, in terms of a classification of its subject.",
          "$comment": "Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice - and can be provided to report of a statement's conclusion in user-friendly terms. For example, in a Statement assessing the proposition that \"BRCA2 c.8023A>G is pathogenic for Breast Cancer\", and reporting a direction of 'supports' and strength of 'likely', the term  'likely pathogenic' from the ACMG Variant Interpretation Guidelines would be used as a subject classification.",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       },
       "hasEvidenceLines": {
          "type": "array",
@@ -145,10 +145,10 @@
          "items": {
             "anyOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/EvidenceLine"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                }
             ]
          },

--- a/schema/va-spec/base/json/StudyGroup
+++ b/schema/va-spec/base/json/StudyGroup
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/StudyGroup",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/StudyGroup",
    "title": "StudyGroup",
    "type": "object",
    "maturity": "trial use",
@@ -32,7 +32,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -53,7 +53,7 @@
       "characteristics": {
          "type": "array",
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
          },
          "ordered": false,
          "description": "A feature or role shared by all members of the StudyGroup, representing a criterion for membership in the group.",

--- a/schema/va-spec/base/json/StudyResult
+++ b/schema/va-spec/base/json/StudyResult
@@ -1,19 +1,19 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/StudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/StudyResult",
    "title": "StudyResult",
    "maturity": "trial use",
    "description": "A collection of data items from a single study that pertain to a particular subject or experimental unit in the study, along with optional provenance information describing how these data items were generated.",
    "$comment": "StudyResults provide a useful way to capture a subset of items from a study dataset that are used as evidence in generating higher order knowledge assertions about the entity that is the focus of the study result. For example, a set of allele frequency data items about a particular variant of interest selected from the complete gnomAD dataset can be reported in a StudyResult object, along with relevant provenance information, so they can be referenced together as evidence for a higher-order assertion about the variant's pathogenicity. Note that a 'dataItem' attribute, which would hold an array of data selected for inclusion in the StudyResult, is not included in this version of the StudyResult class. Profiles that extend this core class can define data type specific attributes to capture such information (e.g.'focusAlleleCount', 'focusAlleleFrequency', and 'locusAlleleCount' attributes in a CohortAlleleFrequencyStudyResult profile). But technical limitations in our current profiling framework tooling forced us to omit a core 'dataItems attribute that these specialized attributes would conceptually extend.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/CohortAlleleFrequencyStudyResult"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/CohortAlleleFrequencyStudyResult"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ComputationalVariantFunctionalImpactAnalysisResult"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ComputationalVariantFunctionalImpactAnalysisResult"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ExperimentalVariantFunctionalImpactStudyResult"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ExperimentalVariantFunctionalImpactStudyResult"
       }
    ]
 }

--- a/schema/va-spec/base/json/SubjectVariantProposition
+++ b/schema/va-spec/base/json/SubjectVariantProposition
@@ -1,30 +1,30 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/SubjectVariantProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/SubjectVariantProposition",
    "title": "SubjectVariantProposition",
    "maturity": "trial use",
    "description": "A Proposition that has a variant as the subject.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ExperimentalVariantFunctionalImpactProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ExperimentalVariantFunctionalImpactProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantClinicalSignificanceProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantClinicalSignificanceProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantDiagnosticProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantDiagnosticProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantOncogenicityProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantOncogenicityProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPathogenicityProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPathogenicityProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantPrognosticProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPrognosticProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantTherapeuticResponseProposition"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantTherapeuticResponseProposition"
       }
    ]
 }

--- a/schema/va-spec/base/json/Therapy
+++ b/schema/va-spec/base/json/Therapy
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/Therapy",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Therapy",
    "title": "Therapy",
    "maturity": "trial use",
    "description": "A specialization of MappableConcept representing an individual therapy (drug, procedure, behavioral intervention, etc.). Allowed conceptType values include: Therapy, Absent, Drug, Procedure, Behavioral Intervention.",
    "$comment": "At present, individual therapies are represented using this specialization of MappableConcept, that captures a code or name for the therapy, along with optional mappings and metadata about the code system. Groups of therapies are represented using the TherapyGroup class, which are collections of 2 or more therapies, each represented as a MappableConcept.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       },
       {
          "properties": {

--- a/schema/va-spec/base/json/TherapyGroup
+++ b/schema/va-spec/base/json/TherapyGroup
@@ -1,13 +1,13 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/TherapyGroup",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/TherapyGroup",
    "title": "TherapyGroup",
    "maturity": "trial use",
    "description": "A specialization of ConceptSet representing a group of two or more therapies that are applied in combination to a single patient/subject, or applied individually to a different subset of participants in a research study. Concepts are restricted to Therapy and TherapyGroup members.",
    "$comment": "The membershipOperator value 'AND' indicates that all therapies in the group were applied in combination to a given patient or subject. The value 'OR' indicates that each therapy was applied individually to a distinct subset of participants in the cohort that was interrogated in a given study. `OR` should be used only in the specific scenario where a study is done on a cohort of individuals that receive one of the therapies in the group - and the treatment response is determined based on an aggregate statistical analysis across all members of this mixed cohort. In such cases, the study does not provide the statistical power to make a conclusion about response to each therapy individually. Therapies in such groups are typically related in their treatment mechanism (e.g. members of the same drug class), and recipients are pooled to make a single cohort that is large enough support a statistically significant results about that class of treatments. Future iterations of the VA-Spec may support representation of these categorical groupings of therapies, but for now we capture the individual therapies used in the study in a TherapyGroup.",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/ConceptSet"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/ConceptSet"
       },
       {
          "properties": {
@@ -17,10 +17,10 @@
                "items": {
                   "oneOf": [
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Therapy"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Therapy"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/TherapyGroup"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/TherapyGroup"
                      }
                   ]
                }

--- a/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
+++ b/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/TumorVariantFrequencyStudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/TumorVariantFrequencyStudyResult",
    "title": "TumorVariantFrequencyStudyResult",
    "maturity": "draft",
    "type": "object",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -39,10 +39,10 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Method"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "A specification that describes all or part of the process that led to creation of the Information Entity",
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -63,10 +63,10 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Document"
                },
                {
-                  "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                }
             ]
          },
@@ -94,20 +94,20 @@
          "default": "TumorVariantFrequencyStudyResult"
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/DataSet",
          "description": "The dataset from which data in the Tumor Variant Frequency Study Result was taken.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance. If use cases for this arise we can make this attribute take an array of DataSets."
       },
       "focusVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
             }
          ],
          "description": "The variant for which frequency data is reported in the Study Result.",
@@ -126,7 +126,7 @@
          "description": "The frequency of tumor samples that include the focus variant in the sample group."
       },
       "sampleGroup": {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/StudyGroup",
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/StudyGroup",
          "description": "The set of samples about which the frequency data was generated."
       },
       "subGroupFrequency": {
@@ -134,7 +134,7 @@
          "ordered": false,
          "description": "A list of Tumor Variant Frequency Study Result objects describing variant frequency in different subsets of larger sample group described in the root Study Result. Subgroups can be further subdivided into more subgroups. This enables, for example, further breakdown of frequency measures in sample groups with a narrower categorical variant than the root focus variant, or sample groups with a more specific tumor type.",
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/TumorVariantFrequencyStudyResult"
+            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/TumorVariantFrequencyStudyResult"
          }
       }
    },

--- a/schema/va-spec/base/json/VariantClinicalSignificanceProposition
+++ b/schema/va-spec/base/json/VariantClinicalSignificanceProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/VariantClinicalSignificanceProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantClinicalSignificanceProposition",
    "title": "VariantClinicalSignificanceProposition",
    "type": "object",
    "maturity": "draft",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -91,13 +91,13 @@
       "objectCondition": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ConditionSet"
             }
          ],
          "description": "The condition that is evaluated.",

--- a/schema/va-spec/base/json/VariantDiagnosticProposition
+++ b/schema/va-spec/base/json/VariantDiagnosticProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/VariantDiagnosticProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantDiagnosticProposition",
    "title": "VariantDiagnosticProposition",
    "type": "object",
    "maturity": "trial use",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -93,13 +93,13 @@
       "objectCondition": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ConditionSet"
             }
          ],
          "description": "The disease that is evaluated for diagnosis.",

--- a/schema/va-spec/base/json/VariantMolecularConsequenceProposition
+++ b/schema/va-spec/base/json/VariantMolecularConsequenceProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/VariantMolecularConsequenceProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantMolecularConsequenceProposition",
    "title": "VariantMolecularConsequenceProposition",
    "maturity": "draft",
    "type": "object",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -46,13 +46,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Adjacency"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Adjacency"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
             }
          ],
          "description": "MUST be a genomic variant specified against genomic reference sequence(s). This practice most directly reflects data conventions from sources like VEP, and aligns with the intended use of Molecular Consequence data. There are separate qualifier attributes in the model to capture transcript and/or protein level representations of the subject, that indicate the variant context in which the reported consequence(s) are actually manifest.",
@@ -68,13 +68,13 @@
       "objectConsequence": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/ConceptSet"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/ConceptSet"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ],
          "description": "The molecular consequence(s) of the subject variant, in the context of the qualifying transcript and/or protein variation context(s). These are typically terms from the 'structural_variant' branch of the Sequence Ontology, e.g. 'SO:0001627' (intron_variant), or 'SO:0001589' (frameshift_variant). If more than one consequence term apply, use a ConceptSet to capture them.",
@@ -84,13 +84,13 @@
          "description": "The subject genomic variant as projected on a particular transcript or mRNA molecule. The reported relationship between the subject variant and object consequence terms holds specifically in the context of this transcript variation. A transcript variation context MUST be reported, unless the subject is an intergenic variant.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Adjacency"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Adjacency"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
             }
          ]
       },
@@ -98,13 +98,13 @@
          "description": "The subject genomic variant as projected on a particular protein molecule. The reported relationship between the subject variant and object consequence terms holds specifically in the context of this protein variation. A protein variation context MUST be accompanied by its corresponding transcript variation context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Adjacency"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Adjacency"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/Allele"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Allele"
             }
          ]
       },
@@ -112,10 +112,10 @@
          "description": "The gene for which this statement reports a VariantMolecularConsequence.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       }

--- a/schema/va-spec/base/json/VariantOncogenicityProposition
+++ b/schema/va-spec/base/json/VariantOncogenicityProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/VariantOncogenicityProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantOncogenicityProposition",
    "title": "VariantOncogenicityProposition",
    "maturity": "trial use",
    "type": "object",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -91,13 +91,13 @@
       "objectTumorType": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ConditionSet"
             }
          ],
          "description": "The tumor type for which the variant impact is evaluated.",

--- a/schema/va-spec/base/json/VariantPathogenicityProposition
+++ b/schema/va-spec/base/json/VariantPathogenicityProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/VariantPathogenicityProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPathogenicityProposition",
    "title": "VariantPathogenicityProposition",
    "maturity": "trial use",
    "type": "object",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -91,13 +91,13 @@
       "objectCondition": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ConditionSet"
             }
          ],
          "description": "The Condition or ConditionSetfor which the variant impact is stated.",
@@ -105,11 +105,11 @@
       },
       "penetranceQualifier": {
          "description": "Reports the penetrance of the pathogenic effect - i.e. the extent to which the variant impact is expressed by individuals carrying it as a measure of the proportion of carriers exhibiting the condition.",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       },
       "modeOfInheritanceQualifier": {
          "description": "Reports a pattern of inheritance expected for the pathogenic effect of the variant. Consider using terms or codes from community terminologies here - e.g. terms from the 'Mode of inheritance' branch of the Human Phenotype Ontology such as HP:0000006 (autosomal dominant inheritance).",
-         "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
       }
    },
    "required": [

--- a/schema/va-spec/base/json/VariantPrognosticProposition
+++ b/schema/va-spec/base/json/VariantPrognosticProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/VariantPrognosticProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantPrognosticProposition",
    "title": "VariantPrognosticProposition",
    "type": "object",
    "maturity": "trial use",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -93,13 +93,13 @@
       "objectCondition": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ConditionSet"
             }
          ],
          "description": "The disease that is evaluated for outcome.",

--- a/schema/va-spec/base/json/VariantTherapeuticResponseProposition
+++ b/schema/va-spec/base/json/VariantTherapeuticResponseProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/json/VariantTherapeuticResponseProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantTherapeuticResponseProposition",
    "title": "VariantTherapeuticResponseProposition",
    "maturity": "trial use",
    "type": "object",
@@ -31,7 +31,7 @@
          "type": "array",
          "ordered": false,
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Extension"
+            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Extension"
          },
          "description": "A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.",
          "$comment": "Extension objects have a key-value data structure that allows definition of custom fields in the data itself. Extensions are not expected to be natively understood, but may be used for pre-negotiated exchange of message attributes between systems."
@@ -39,13 +39,13 @@
       "subjectVariant": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/cat-vrs/1.0.0/json/CategoricalVariant"
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.0.1/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation"
             }
          ],
          "description": "A variant that is the subject of the Proposition.",
@@ -56,10 +56,10 @@
          "$comment": "This is not a required field, and should be used when information about the gene context of the subject variant is known, relevant, and not apparent from the representation of the variant itself. It is useful for simpler variants such as SNVs where we cannot infer the gene context, but not necessary for complex variants like gene fusions, whose Cat-VRS representations reference specific transcripts and/or genes that provide a built-in gene context.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -67,10 +67,10 @@
          "description": "Reports whether the Proposition should be interpreted in the context of a heritable \"germline\" variant, an acquired \"somatic\" variant in a tumor, or a post-zygotic \"mosaic\" variant. While these are the most commonly reported allele origins, other more nuanced concepts can be captured  (e.g. \"maternal\" vs \"paternal\" allele origin). In practice, populating this field may be complicated by the fact that some sources report allele origin based on the type of tissue that was sequenced to identify the variant, and others use it more generally to specify a category of variant for which the proposition holds. The stated intent of this attribute is the latter. However, if an implementer is not sure about which is reported in their data, it may be safer to create an Extension to hold this information, where they can explicitly acknowledge this ambiguity.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/MappableConcept"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
          ]
       },
@@ -93,13 +93,13 @@
       "objectTherapy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Therapy"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Therapy"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/TherapyGroup"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/TherapyGroup"
             }
          ],
          "description": "A drug administration or other therapeutic procedure that the neoplasm is intended to respond to.",
@@ -108,13 +108,13 @@
       "conditionQualifier": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/ConditionSet"
             }
          ],
          "description": "Reports the disease context in which the variant's association with therapeutic sensitivity or resistance is evaluated. Note that this is a required qualifier in therapeutic response propositions."

--- a/schema/va-spec/base/va-core-source.yaml
+++ b/schema/va-spec/base/va-core-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.1/base/va-spec-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/va-spec-source.yaml"
 title: VA Specification Core classes
 strict: true
 
@@ -10,9 +10,9 @@ imports:
   gks-core: ../../gks-core/gks-core-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
-  vrs: /ga4gh/schema/vrs/2.0.1/json/
-  cat-vrs: /ga4gh/schema/cat-vrs/1.0.0/json/
+  gks.core: /ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/
+  vrs: /ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/
+  cat-vrs: /ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/
 
 $defs:
   # abstract core classes section -- InformationEntity, Activity, StudyResult, Proposition

--- a/schema/va-spec/ccv-2022/def/VariantOncogenicityEvidenceLine.rst
+++ b/schema/va-spec/ccv-2022/def/VariantOncogenicityEvidenceLine.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 An Evidence Line that describes how evidence for a variant was interpreted to determine if a specific CCV 2022 criterion code is met, and the strength that evidence this provides for or against the variant's oncogenicity. An Evidence Line that describes how a specific type of information was interpreted as evidence for or against a variant's oncogenicity. In the CCV Framework, evidence is assessed by determining if a specific criterion (e.g. 'OM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the default strength based on the quality and abundance of evidence.
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/ccv-2022/def/VariantOncogenicityStatement.rst
+++ b/schema/va-spec/ccv-2022/def/VariantOncogenicityStatement.rst
@@ -5,3 +5,18 @@
 **Computational Definition**
 
 A statement reporting a conclusion from a single study about whether a variant is associated with oncogenicity (positive or negative) - based on interpretation of the study's results.
+
+**Information Model**
+
+
+.. list-table::
+   :class: clean-wrap
+   :header-rows: 1
+   :align: left
+   :widths: auto
+
+   *  - Field
+      - Flags
+      - Type
+      - Limits
+      - Description

--- a/schema/va-spec/ccv-2022/json/VariantOncogenicityEvidenceLine
+++ b/schema/va-spec/ccv-2022/json/VariantOncogenicityEvidenceLine
@@ -1,18 +1,18 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/ccv-2022/json/VariantOncogenicityEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/ccv-2022/json/VariantOncogenicityEvidenceLine",
    "title": "VariantOncogenicityEvidenceLine",
    "description": "An Evidence Line that describes how evidence for a variant was interpreted to determine if a specific CCV 2022 criterion code is met, and the strength that evidence this provides for or against the variant's oncogenicity. An Evidence Line that describes how a specific type of information was interpreted as evidence for or against a variant's oncogenicity. In the CCV Framework, evidence is assessed by determining if a specific criterion (e.g. 'OM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the default strength based on the quality and abundance of evidence.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/EvidenceLine"
       },
       {
          "properties": {
             "targetProposition": {
                "description": "A Variant Oncogenicity Proposition against which a specific type of evidence was assessed, to determine the strength and direction of support this evidence provides for or against the proposition's validity.",
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantOncogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantOncogenicityProposition"
             },
             "directionOfEvidenceProvided": {
                "type": "string",
@@ -29,7 +29,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Coding"
                         },
                         {
                            "properties": {

--- a/schema/va-spec/ccv-2022/json/VariantOncogenicityStatement
+++ b/schema/va-spec/ccv-2022/json/VariantOncogenicityStatement
@@ -1,17 +1,17 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.0.1/ccv-2022/json/VariantOncogenicityStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/ccv-2022/json/VariantOncogenicityStatement",
    "title": "VariantOncogenicityStatement",
    "description": "A statement reporting a conclusion from a single study about whether a variant is associated with oncogenicity (positive or negative) - based on interpretation of the study's results.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.0.1/base/json/VariantOncogenicityProposition",
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantOncogenicityProposition",
                "description": "A proposition about the oncogenicity of a variant, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
@@ -20,7 +20,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Coding"
                         },
                         {
                            "properties": {
@@ -44,7 +44,7 @@
                   "primaryCoding": {
                      "allOf": [
                         {
-                           "$ref": "/ga4gh/schema/gks-core/1.1.0/json/Coding"
+                           "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/Coding"
                         },
                         {
                            "properties": {
@@ -74,10 +74,10 @@
                "items": {
                   "anyOf": [
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.0.1/ccv-2022/json/VariantOncogenicityEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/ccv-2022/json/VariantOncogenicityEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/gks-core/1.1.0/json/iriReference"
+                        "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                      }
                   ]
                }

--- a/schema/va-spec/ccv-2022/profile-source.yaml
+++ b/schema/va-spec/ccv-2022/profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.0.1/ccv-2022/profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/ccv-2022/profile-source.yaml"
 title: CCV 2022 Variant Oncogenicity Profiles
 description: >-
   Profiles defined to align with terminology and conventions from the Clinical Genome Resource (ClinGen),
@@ -11,7 +11,7 @@ imports:
   gks-core: ../../gks-core/gks-core-source.yaml
 
 namespaces:
-  gks.core: /ga4gh/schema/gks-core/1.1.0/json/
+  gks.core: /ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/
 
 $defs:
   VariantOncogenicityStatement:
@@ -21,10 +21,10 @@ $defs:
       is associated with oncogenicity (positive or negative) - based on interpretation of the study's
       results.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/Statement"
+      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/Statement"
       - properties:
           proposition:
-            $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantOncogenicityProposition"
+            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantOncogenicityProposition"
             description: >-
               A proposition about the oncogenicity of a variant, for which the study provides evidence.
               The validity of this proposition, and the level of confidence/evidence supporting it,
@@ -88,14 +88,14 @@ $defs:
       (e.g. 'OM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the
       default strength based on the quality and abundance of evidence.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/EvidenceLine"
+      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/EvidenceLine"
       - properties:
           targetProposition:
             description: >-
               A Variant Oncogenicity Proposition against which a specific type of evidence was assessed, to
               determine the strength and direction of support this evidence provides for or against the
               proposition's validity.
-            $ref: "/ga4gh/schema/va-spec/1.0.1/base/json/VariantOncogenicityProposition"
+            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.1/base/json/VariantOncogenicityProposition"
           directionOfEvidenceProvided:
             type: string
             enum: ["supports", "neutral", "disputes"]

--- a/tests/fixtures/EVFI-proposition.yaml
+++ b/tests/fixtures/EVFI-proposition.yaml
@@ -22,13 +22,15 @@ subjectVariant:
           - syntax: hgvs.p
             value: NP_000305.3:p.Arg11Thr
       relations:
-        - primaryCoding:
+        - type: MappableConcept
+          primaryCoding:
             code: translation_of
             system: http://www.sequenceontology.org
             iris:
               - http://www.sequenceontology.org/browser/current_release/term/translation_of
 predicate: impactsFunctionOf
 objectSequenceFeature:
+  type: MappableConcept
   id: clinvar-gene:5728
   conceptType: Gene
   primaryCoding:

--- a/tests/fixtures/Exp-Var-Func-Impact-Statement-01.yaml
+++ b/tests/fixtures/Exp-Var-Func-Impact-Statement-01.yaml
@@ -24,13 +24,15 @@ proposition:
             - syntax: hgvs.p
               value: NP_000305.3:p.Arg11Thr
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
               iris:
                 - http://www.sequenceontology.org/browser/current_release/term/translation_of
   predicate: impactsFunctionOf
   objectSequenceFeature:
+    type: MappableConcept
     id: clinvar-gene:5728
     conceptType: Gene
     primaryCoding:
@@ -141,6 +143,7 @@ proposition:
       profilingStrategy: barcode sequencing
       sequencingReadType: single-segment (short read)
 classification:
+  type: MappableConcept
   primaryCoding:
     code: normal
     system: ga4gh-gks-term:experimental-var-func-impact-classification

--- a/tests/fixtures/Exp-Var-Func-Impact-Study-Result-01.yaml
+++ b/tests/fixtures/Exp-Var-Func-Impact-Study-Result-01.yaml
@@ -27,6 +27,7 @@ sourceDataSet:
     type: DataSet
     name: variant effect data set
     license:
+      type: MappableConcept
       primaryCoding:
         code: CC0
         system: https://spdx.org/licenses/

--- a/tests/fixtures/VA-ClinVar-SCV-Example-001.yaml
+++ b/tests/fixtures/VA-ClinVar-SCV-Example-001.yaml
@@ -33,16 +33,19 @@ proposition:
             - syntax: spdi
               value: NC_000001.11:40819438:CTCCTCCT:CTCCT
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: liftover_to
               system: ga4gh-gks-term:allele-relation
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: transcribed_to
               system: https://www.sequenceontology.org/
               iris:
                 - http://www.sequenceontology.org/browser/current_release/term/transcribed_to
   predicate: isCausalFor
   objectCondition:
+    type: MappableConcept
     id: clinvar.trait/939
     conceptType: Disease
     name: Autosomal dominant nonsyndromic hearing loss 2A
@@ -52,16 +55,19 @@ proposition:
       iris:
         - http://identifiers.org/medgen/C2677637
   penetranceQualifier:
+    type: MappableConcept
     primaryCoding:
       code: high
       system: ga4gh-gks-term:pathogenicity-penetrance-qualifier
     name: high
 direction: supports
 strength:
+  type: MappableConcept
   primaryCoding:
     code: definitive
     system: ACMG Guidelines, 2015
 classification:
+  type: MappableConcept
   primaryCoding:
     code: pathogenic
     system: ACMG Guidelines, 2015

--- a/tests/fixtures/VA-ClinVar-SCV-Example-002.yaml
+++ b/tests/fixtures/VA-ClinVar-SCV-Example-002.yaml
@@ -5,6 +5,7 @@ proposition:
   subjectVariant: catvars-mvp.jsonc#/208366 # NOQA: IRI resolution not tested; inline
                                     # version of this object tested in SCV example 1
   objectCondition:
+    type: MappableConcept
     id: clinvarTrait:9544 # This ID syntax is clinvar.trait/9544 in example 1. Both OK.
     conceptType: Disease
     name: Nonsyndromic genetic hearing loss
@@ -16,10 +17,12 @@ proposition:
   predicate: isCausalFor
 direction: supports
 strength:
+  type: MappableConcept
   primaryCoding:
     code: likely
     system: ACMG Guidelines, 2015
 classification:
+  type: MappableConcept
   primaryCoding:
     code: likely pathogenic
     system: ACMG Guidelines, 2015

--- a/tests/fixtures/Var-Onco-Func-Impact-Evidence-Line-02.yaml
+++ b/tests/fixtures/Var-Onco-Func-Impact-Evidence-Line-02.yaml
@@ -24,13 +24,15 @@ targetProposition:
             - syntax: hgvs.p
               value: NP_000305.3:p.Arg11Thr
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
               iris:
                 - http://www.sequenceontology.org/browser/current_release/term/translation_of
   predicate: isOncogenicFor
   objectTumorType:
+    type: MappableConcept
     primaryCoding:
       code: ncit:C4872
       system: https://www.ebi.ac.uk/ols4/ontologies/ncit
@@ -38,6 +40,7 @@ targetProposition:
         - http://purl.obolibrary.org/obo/NCIT_C4872C4872
     name: Breast Carcinoma
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     name: EGFR
     primaryCoding:
@@ -47,6 +50,7 @@ targetProposition:
         - http://identifiers.org/ncbigene/1956
 directionOfEvidenceProvided: supports
 strengthOfEvidenceProvided:
+  type: MappableConcept
   primaryCoding:
     code: supporting
     system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
@@ -59,6 +63,7 @@ specifiedBy:
     pmid: '35101336'
     name: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
 evidenceOutcome:
+  type: MappableConcept
   primaryCoding:
     code: OS2_supporting
     system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022

--- a/tests/fixtures/Var-Path-Func-Impact-Evidence-Line-01.yaml
+++ b/tests/fixtures/Var-Path-Func-Impact-Evidence-Line-01.yaml
@@ -25,20 +25,24 @@ targetProposition:
             - syntax: hgvs.p
               value: NP_000305.3:p.Arg11Thr
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
               iris:
                 - http://www.sequenceontology.org/browser/current_release/term/translation_of
   predicate: isCausalFor
   objectCondition:
+    type: MappableConcept
     conceptType: Disease
     name: Unspecified
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     name: PTEN
 directionOfEvidenceProvided: supports
 strengthOfEvidenceProvided:
+  type: MappableConcept
   primaryCoding:
     code: supporting
     system: ACMG Guidelines, 2015
@@ -51,6 +55,7 @@ specifiedBy:
     pmid: '25741868'
     name: ACMG Guidelines, 2015
 evidenceOutcome:
+  type: MappableConcept
   primaryCoding:
     code: PS3_supporting
     system: ACMG Guidelines, 2015

--- a/tests/fixtures/adm-study-group.yaml
+++ b/tests/fixtures/adm-study-group.yaml
@@ -2,5 +2,6 @@ id: amr
 name: Admixed American Ancestry Group
 type: StudyGroup
 characteristics:
-- conceptType: genetic ancestry
+- type: MappableConcept
+  conceptType: genetic ancestry
   name: Admixed American

--- a/tests/fixtures/cadd-prediction-analysis-result.yaml
+++ b/tests/fixtures/cadd-prediction-analysis-result.yaml
@@ -39,6 +39,7 @@ transcriptVariationContext:
       value: ENST00000366667.6:c.803C>T
 impactScore: 11.7
 impactScoreType:
+  type: MappableConcept
   primaryCoding:
     code: phred
     system: cadd-score-types

--- a/tests/fixtures/civic-assertion-combination-therapy-inline.yaml
+++ b/tests/fixtures/civic-assertion-combination-therapy-inline.yaml
@@ -1,4 +1,5 @@
 classification:
+  type: MappableConcept
   name: Tier I
   primaryCoding:
     code: tier i
@@ -28,6 +29,7 @@ hasEvidenceLines:
         id: civic.eid:6178
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -37,6 +39,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:7
             mappings:
@@ -46,6 +49,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Melanoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -99,9 +103,11 @@ hasEvidenceLines:
                 relation: exactMatch
             name: BRAF
           objectTherapy:
+            type: ConceptSet
             membershipOperator: AND
             concepts:
-              - conceptType: Therapy
+              - type: MappableConcept
+                conceptType: Therapy
                 extensions:
                   - name: aliases
                     value:
@@ -121,7 +127,8 @@ hasEvidenceLines:
                       system: https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=
                     relation: exactMatch
                 name: Dabrafenib
-              - conceptType: Therapy
+              - type: MappableConcept
+                conceptType: Therapy
                 extensions:
                   - name: aliases
                     value:
@@ -178,10 +185,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -369,6 +378,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -394,6 +404,7 @@ hasEvidenceLines:
         id: civic.eid:6938
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -403,6 +414,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:7
             mappings:
@@ -412,6 +424,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Melanoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -465,9 +478,11 @@ hasEvidenceLines:
                 relation: exactMatch
             name: BRAF
           objectTherapy:
+            type: ConceptSet
             membershipOperator: AND
             concepts:
-              - conceptType: Therapy
+              - type: MappableConcept
+                conceptType: Therapy
                 extensions:
                   - name: aliases
                     value:
@@ -487,7 +502,8 @@ hasEvidenceLines:
                       system: https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=
                     relation: exactMatch
                 name: Dabrafenib
-              - conceptType: Therapy
+              - type: MappableConcept
+                conceptType: Therapy
                 extensions:
                   - name: aliases
                     value:
@@ -544,10 +560,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -735,6 +753,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -758,6 +777,7 @@ hasEvidenceLines:
         id: civic.eid:3758
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -767,6 +787,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:206
             mappings:
@@ -776,6 +797,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Skin Melanoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -829,9 +851,11 @@ hasEvidenceLines:
                 relation: exactMatch
             name: BRAF
           objectTherapy:
+            type: ConceptSet
             membershipOperator: AND
             concepts:
-              - conceptType: Therapy
+              - type: MappableConcept
+                conceptType: Therapy
                 extensions:
                   - name: aliases
                     value:
@@ -851,7 +875,8 @@ hasEvidenceLines:
                       system: https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=
                     relation: exactMatch
                 name: Dabrafenib
-              - conceptType: Therapy
+              - type: MappableConcept
+                conceptType: Therapy
                 extensions:
                   - name: aliases
                     value:
@@ -908,10 +933,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -1099,6 +1126,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -1121,6 +1149,7 @@ hasEvidenceLines:
         id: civic.eid:6940
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -1130,6 +1159,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:7
             mappings:
@@ -1139,6 +1169,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Melanoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -1192,9 +1223,11 @@ hasEvidenceLines:
                 relation: exactMatch
             name: BRAF
           objectTherapy:
+            type: ConceptSet
             membershipOperator: AND
             concepts:
-              - conceptType: Therapy
+              - type: MappableConcept
+                conceptType: Therapy
                 extensions:
                   - name: aliases
                     value:
@@ -1214,7 +1247,8 @@ hasEvidenceLines:
                       system: https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=
                     relation: exactMatch
                 name: Dabrafenib
-              - conceptType: Therapy
+              - type: MappableConcept
+                conceptType: Therapy
                 extensions:
                   - name: aliases
                     value:
@@ -1271,10 +1305,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -1463,6 +1499,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -1475,11 +1512,13 @@ hasEvidenceLines:
             system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
         type: Statement
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: A
         system: AMP/ASCO/CAP Guidelines, 2017
     targetProposition:
       alleleOriginQualifier:
+        type: MappableConcept
         mappings:
           - coding:
               code: SOMATIC
@@ -1489,6 +1528,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: somatic
       conditionQualifier:
+        type: MappableConcept
         conceptType: Disease
         id: civic.did:7
         mappings:
@@ -1498,6 +1538,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: Melanoma
       geneContextQualifier:
+        type: MappableConcept
         conceptType: Gene
         extensions:
           - name: aliases
@@ -1549,9 +1590,11 @@ hasEvidenceLines:
             relation: exactMatch
         name: BRAF
       objectTherapy:
+        type: ConceptSet
         membershipOperator: AND
         concepts:
-          - conceptType: Therapy
+          - type: MappableConcept
+            conceptType: Therapy
             extensions:
               - name: aliases
                 value:
@@ -1571,7 +1614,8 @@ hasEvidenceLines:
                   system: https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&code=
                 relation: exactMatch
             name: Dabrafenib
-          - conceptType: Therapy
+          - type: MappableConcept
+            conceptType: Therapy
             extensions:
               - name: aliases
                 value:
@@ -1628,10 +1672,12 @@ hasEvidenceLines:
                 type: LiteralSequenceExpression
               type: Allele
             relations:
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: liftover_to
                   system: ga4gh-gks-term:allele-relation
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: translation_of
                   system: http://www.sequenceontology.org
             type: DefiningAlleleConstraint
@@ -1792,6 +1838,7 @@ hasEvidenceLines:
 id: civic.aid:7
 proposition:
   alleleOriginQualifier:
+    type: MappableConcept
     mappings:
       - coding:
           code: SOMATIC
@@ -1801,6 +1848,7 @@ proposition:
         relation: exactMatch
     name: somatic
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     extensions:
       - name: aliases
@@ -1852,6 +1900,7 @@ proposition:
         relation: exactMatch
     name: BRAF
   objectCondition:
+    type: MappableConcept
     conceptType: Disease
     id: civic.did:7
     mappings:
@@ -1893,10 +1942,12 @@ proposition:
             type: LiteralSequenceExpression
           type: Allele
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: liftover_to
               system: ga4gh-gks-term:allele-relation
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
         type: DefiningAlleleConstraint
@@ -2112,6 +2163,7 @@ specifiedBy:
       - https://pubmed.ncbi.nlm.nih.gov/31779674/
   type: Method
 strength:
+  type: MappableConcept
   primaryCoding:
     code: strong
     system: AMP/ASCO/CAP Guidelines, 2017

--- a/tests/fixtures/civic-assertion-diagnostic-inline.yaml
+++ b/tests/fixtures/civic-assertion-diagnostic-inline.yaml
@@ -1,4 +1,5 @@
 classification:
+  type: MappableConcept
   name: Tier II
   primaryCoding:
     code: tier ii
@@ -25,6 +26,7 @@ hasEvidenceLines:
         id: civic.eid:4846
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -34,6 +36,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -55,6 +58,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: ACVR1
           objectCondition:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:2950
             mappings:
@@ -124,6 +128,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -136,11 +141,13 @@ hasEvidenceLines:
             system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
         type: Statement
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: C
         system: AMP/ASCO/CAP Guidelines, 2017
     targetProposition:
       alleleOriginQualifier:
+        type: MappableConcept
         mappings:
           - coding:
               code: SOMATIC
@@ -150,6 +157,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: somatic
       geneContextQualifier:
+        type: MappableConcept
         conceptType: Gene
         extensions:
           - name: aliases
@@ -171,6 +179,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: ACVR1
       objectCondition:
+        type: MappableConcept
         conceptType: Disease
         id: civic.did:2950
         mappings:
@@ -210,10 +219,12 @@ hasEvidenceLines:
                 type: LiteralSequenceExpression
               type: Allele
             relations:
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: liftover_to
                   system: ga4gh-gks-term:allele-relation
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: translation_of
                   system: http://www.sequenceontology.org
             type: DefiningAlleleConstraint
@@ -361,6 +372,7 @@ hasEvidenceLines:
 id: civic.aid:9
 proposition:
   alleleOriginQualifier:
+    type: MappableConcept
     mappings:
       - coding:
           code: SOMATIC
@@ -370,6 +382,7 @@ proposition:
         relation: exactMatch
     name: somatic
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     extensions:
       - name: aliases
@@ -391,6 +404,7 @@ proposition:
         relation: exactMatch
     name: ACVR1
   objectCondition:
+    type: MappableConcept
     conceptType: Disease
     id: civic.did:2950
     mappings:
@@ -430,10 +444,12 @@ proposition:
             type: LiteralSequenceExpression
           type: Allele
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: liftover_to
               system: ga4gh-gks-term:allele-relation
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
         type: DefiningAlleleConstraint
@@ -621,6 +637,7 @@ specifiedBy:
       - https://pubmed.ncbi.nlm.nih.gov/31779674/
   type: Method
 strength:
+  type: MappableConcept
   primaryCoding:
     code: potential
     system: AMP/ASCO/CAP Guidelines, 2017

--- a/tests/fixtures/civic-assertion-diagnostic-phenotypes-inline.yaml
+++ b/tests/fixtures/civic-assertion-diagnostic-phenotypes-inline.yaml
@@ -1,4 +1,5 @@
 classification:
+  type: MappableConcept
   name: Tier I
   primaryCoding:
     code: tier i
@@ -38,6 +39,7 @@ hasEvidenceLines:
         id: civic.eid:11780
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -47,6 +49,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -63,8 +66,10 @@ hasEvidenceLines:
                 relation: exactMatch
             name: MYBL1
           objectCondition:
+            type: ConceptSet
             concepts:
-              - conceptType: Disease
+              - type: MappableConcept
+                conceptType: Disease
                 id: civic.did:3387
                 mappings:
                   - coding:
@@ -72,8 +77,10 @@ hasEvidenceLines:
                       system: https://disease-ontology.org/?id=
                     relation: exactMatch
                 name: Diffuse Astrocytoma, MYB- Or MYBL1-altered
-              - concepts:
-                  - conceptType: Phenotype
+              - type: ConceptSet
+                concepts:
+                  - type: MappableConcept
+                    conceptType: Phenotype
                     id: civic.phenotype:2656
                     mappings:
                       - coding:
@@ -81,7 +88,8 @@ hasEvidenceLines:
                           system: https://hpo.jax.org/app/browse/term/
                         relation: exactMatch
                     name: Juvenile onset
-                  - conceptType: Phenotype
+                  - type: MappableConcept
+                    conceptType: Phenotype
                     id: civic.phenotype:8120
                     mappings:
                       - coding:
@@ -89,7 +97,8 @@ hasEvidenceLines:
                           system: https://hpo.jax.org/app/browse/term/
                         relation: exactMatch
                     name: Young adult onset
-                  - conceptType: Phenotype
+                  - type: MappableConcept
+                    conceptType: Phenotype
                     id: civic.phenotype:2647
                     mappings:
                       - coding:
@@ -161,6 +170,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -192,6 +202,7 @@ hasEvidenceLines:
         id: civic.eid:11781
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -201,6 +212,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -217,8 +229,10 @@ hasEvidenceLines:
                 relation: exactMatch
             name: MYBL1
           objectCondition:
+            type: ConceptSet
             concepts:
-              - conceptType: Disease
+              - type: MappableConcept
+                conceptType: Disease
                 id: civic.did:3387
                 mappings:
                   - coding:
@@ -226,8 +240,10 @@ hasEvidenceLines:
                       system: https://disease-ontology.org/?id=
                     relation: exactMatch
                 name: Diffuse Astrocytoma, MYB- Or MYBL1-altered
-              - concepts:
-                  - conceptType: Phenotype
+              - type: ConceptSet
+                concepts:
+                  - type: MappableConcept
+                    conceptType: Phenotype
                     id: civic.phenotype:8121
                     mappings:
                       - coding:
@@ -235,7 +251,8 @@ hasEvidenceLines:
                           system: https://hpo.jax.org/app/browse/term/
                         relation: exactMatch
                     name: Childhood onset
-                  - conceptType: Phenotype
+                  - type: MappableConcept
+                    conceptType: Phenotype
                     id: civic.phenotype:2656
                     mappings:
                       - coding:
@@ -306,6 +323,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -341,6 +359,7 @@ hasEvidenceLines:
         id: civic.eid:11779
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -350,6 +369,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -366,8 +386,10 @@ hasEvidenceLines:
                 relation: exactMatch
             name: MYBL1
           objectCondition:
+            type: ConceptSet
             concepts:
-              - conceptType: Disease
+              - type: MappableConcept
+                conceptType: Disease
                 id: civic.did:3387
                 mappings:
                   - coding:
@@ -375,8 +397,10 @@ hasEvidenceLines:
                       system: https://disease-ontology.org/?id=
                     relation: exactMatch
                 name: Diffuse Astrocytoma, MYB- Or MYBL1-altered
-              - concepts:
-                  - conceptType: Phenotype
+              - type: ConceptSet
+                concepts:
+                  - type: MappableConcept
+                    conceptType: Phenotype
                     id: civic.phenotype:8121
                     mappings:
                       - coding:
@@ -384,7 +408,8 @@ hasEvidenceLines:
                           system: https://hpo.jax.org/app/browse/term/
                         relation: exactMatch
                     name: Childhood onset
-                  - conceptType: Phenotype
+                  - type: MappableConcept
+                    conceptType: Phenotype
                     id: civic.phenotype:2656
                     mappings:
                       - coding:
@@ -455,6 +480,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000008
@@ -467,11 +493,13 @@ hasEvidenceLines:
             system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
         type: Statement
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: A
         system: AMP/ASCO/CAP Guidelines, 2017
     targetProposition:
       alleleOriginQualifier:
+        type: MappableConcept
         mappings:
           - coding:
               code: SOMATIC
@@ -481,6 +509,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: somatic
       geneContextQualifier:
+        type: MappableConcept
         conceptType: Gene
         extensions:
           - name: aliases
@@ -497,8 +526,10 @@ hasEvidenceLines:
             relation: exactMatch
         name: MYBL1
       objectCondition:
+        type: ConceptSet
         concepts:
-          - conceptType: Disease
+          - type: MappableConcept
+            conceptType: Disease
             id: civic.did:3387
             mappings:
               - coding:
@@ -506,8 +537,10 @@ hasEvidenceLines:
                   system: https://disease-ontology.org/?id=
                 relation: exactMatch
             name: Diffuse Astrocytoma, MYB- Or MYBL1-altered
-          - concepts:
-              - conceptType: Phenotype
+          - type: ConceptSet
+            concepts:
+              - type: MappableConcept
+                conceptType: Phenotype
                 id: civic.phenotype:8121
                 mappings:
                   - coding:
@@ -515,7 +548,8 @@ hasEvidenceLines:
                       system: https://hpo.jax.org/app/browse/term/
                     relation: exactMatch
                 name: Childhood onset
-              - conceptType: Phenotype
+              - type: MappableConcept
+                conceptType: Phenotype
                 id: civic.phenotype:2656
                 mappings:
                   - coding:
@@ -523,7 +557,8 @@ hasEvidenceLines:
                       system: https://hpo.jax.org/app/browse/term/
                     relation: exactMatch
                 name: Juvenile onset
-              - conceptType: Phenotype
+              - type: MappableConcept
+                conceptType: Phenotype
                 id: civic.phenotype:2643
                 mappings:
                   - coding:
@@ -565,6 +600,7 @@ hasEvidenceLines:
 id: civic.aid:115
 proposition:
   alleleOriginQualifier:
+    type: MappableConcept
     mappings:
       - coding:
           code: SOMATIC
@@ -574,6 +610,7 @@ proposition:
         relation: exactMatch
     name: somatic
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     extensions:
       - name: aliases
@@ -590,8 +627,10 @@ proposition:
         relation: exactMatch
     name: MYBL1
   objectCondition:
+    type: ConceptSet
     concepts:
-      - conceptType: Disease
+      - type: MappableConcept
+        conceptType: Disease
         id: civic.did:3387
         mappings:
           - coding:
@@ -599,8 +638,10 @@ proposition:
               system: https://disease-ontology.org/?id=
             relation: exactMatch
         name: Diffuse Astrocytoma, MYB- Or MYBL1-altered
-      - concepts:
-          - conceptType: Phenotype
+      - type: ConceptSet
+        concepts:
+          - type: MappableConcept
+            conceptType: Phenotype
             id: civic.phenotype:8121
             mappings:
               - coding:
@@ -608,7 +649,8 @@ proposition:
                   system: https://hpo.jax.org/app/browse/term/
                 relation: exactMatch
             name: Childhood onset
-          - conceptType: Phenotype
+          - type: MappableConcept
+            conceptType: Phenotype
             id: civic.phenotype:2656
             mappings:
               - coding:
@@ -616,7 +658,8 @@ proposition:
                   system: https://hpo.jax.org/app/browse/term/
                 relation: exactMatch
             name: Juvenile onset
-          - conceptType: Phenotype
+          - type: MappableConcept
+            conceptType: Phenotype
             id: civic.phenotype:2643
             mappings:
               - coding:
@@ -712,6 +755,7 @@ specifiedBy:
       - https://pubmed.ncbi.nlm.nih.gov/31779674/
   type: Method
 strength:
+  type: MappableConcept
   primaryCoding:
     code: strong
     system: AMP/ASCO/CAP Guidelines, 2017

--- a/tests/fixtures/civic-assertion-oncogenicity.yaml
+++ b/tests/fixtures/civic-assertion-oncogenicity.yaml
@@ -1,4 +1,5 @@
 classification:
+  type: MappableConcept
   primaryCoding:
     code: likely oncogenic
     system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
@@ -45,6 +46,7 @@ direction: supports
 hasEvidenceLines:
   - directionOfEvidenceProvided: supports
     evidenceOutcome:
+      type: MappableConcept
       primaryCoding:
         code: OM1
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
@@ -68,12 +70,14 @@ hasEvidenceLines:
           - https://pubmed.ncbi.nlm.nih.gov/35101336/
       type: Method
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: moderate
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
     type: EvidenceLine
   - directionOfEvidenceProvided: supports
     evidenceOutcome:
+      type: MappableConcept
       primaryCoding:
         code: OS2
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
@@ -97,12 +101,14 @@ hasEvidenceLines:
           - https://pubmed.ncbi.nlm.nih.gov/35101336/
       type: Method
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: strong
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
     type: EvidenceLine
   - directionOfEvidenceProvided: supports
     evidenceOutcome:
+      type: MappableConcept
       primaryCoding:
         code: OP4
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
@@ -126,12 +132,14 @@ hasEvidenceLines:
           - https://pubmed.ncbi.nlm.nih.gov/35101336/
       type: Method
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: supporting
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
     type: EvidenceLine
   - directionOfEvidenceProvided: supports
     evidenceOutcome:
+      type: MappableConcept
       primaryCoding:
         code: OP1
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
@@ -155,12 +163,14 @@ hasEvidenceLines:
           - https://pubmed.ncbi.nlm.nih.gov/35101336/
       type: Method
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: supporting
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
     type: EvidenceLine
   - directionOfEvidenceProvided: supports
     evidenceOutcome:
+      type: MappableConcept
       primaryCoding:
         code: OP3
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
@@ -184,6 +194,7 @@ hasEvidenceLines:
           - https://pubmed.ncbi.nlm.nih.gov/35101336/
       type: Method
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: supporting
         system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022
@@ -191,6 +202,7 @@ hasEvidenceLines:
 id: civic.aid:202
 proposition:
   alleleOriginQualifier:
+    type: MappableConcept
     mappings:
       - coding:
           code: SOMATIC
@@ -200,6 +212,7 @@ proposition:
         relation: exactMatch
     name: somatic
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     extensions:
       - name: aliases
@@ -236,6 +249,7 @@ proposition:
         relation: exactMatch
     name: RET
   objectTumorType:
+    type: MappableConcept
     conceptType: Disease
     id: civic.did:15
     mappings:
@@ -273,10 +287,12 @@ proposition:
             type: LiteralSequenceExpression
           type: Allele
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: liftover_to
               system: ga4gh-gks-term:allele-relation
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
         type: DefiningAlleleConstraint
@@ -509,6 +525,7 @@ specifiedBy:
       - https://pubmed.ncbi.nlm.nih.gov/35101336/
   type: Method
 strength:
+  type: MappableConcept
   primaryCoding:
     code: likely
     system: ClinGen/CGC/VICC Guidelines for Oncogenicity, 2022

--- a/tests/fixtures/civic-assertion-prognostic-inline.yaml
+++ b/tests/fixtures/civic-assertion-prognostic-inline.yaml
@@ -1,4 +1,5 @@
 classification:
+  type: MappableConcept
   name: Tier I
   primaryCoding:
     code: tier i
@@ -25,6 +26,7 @@ hasEvidenceLines:
         id: civic.eid:7158
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -34,6 +36,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -87,6 +90,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: BRAF
           objectCondition:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:11
             mappings:
@@ -99,6 +103,7 @@ hasEvidenceLines:
           subjectVariant:
             constraints:
               - featureContext:
+                  type: MappableConcept
                   primaryCoding:
                     code: "673"
                     id: ncbigene:673
@@ -179,6 +184,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -207,6 +213,7 @@ hasEvidenceLines:
         id: civic.eid:7159
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -216,6 +223,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -269,6 +277,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: BRAF
           objectCondition:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:11
             mappings:
@@ -281,6 +290,7 @@ hasEvidenceLines:
           subjectVariant:
             constraints:
               - featureContext:
+                  type: MappableConcept
                   primaryCoding:
                     code: "673"
                     id: ncbigene:673
@@ -359,6 +369,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -371,11 +382,13 @@ hasEvidenceLines:
             system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
         type: Statement
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: A
         system: AMP/ASCO/CAP Guidelines, 2017
     targetProposition:
       alleleOriginQualifier:
+        type: MappableConcept
         mappings:
           - coding:
               code: SOMATIC
@@ -385,6 +398,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: somatic
       geneContextQualifier:
+        type: MappableConcept
         conceptType: Gene
         extensions:
           - name: aliases
@@ -436,6 +450,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: BRAF
       objectCondition:
+        type: MappableConcept
         conceptType: Disease
         id: civic.did:11
         mappings:
@@ -477,10 +492,12 @@ hasEvidenceLines:
                 type: LiteralSequenceExpression
               type: Allele
             relations:
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: liftover_to
                   system: ga4gh-gks-term:allele-relation
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: translation_of
                   system: http://www.sequenceontology.org
             type: DefiningAlleleConstraint
@@ -641,6 +658,7 @@ hasEvidenceLines:
 id: civic.aid:20
 proposition:
   alleleOriginQualifier:
+    type: MappableConcept
     mappings:
       - coding:
           code: SOMATIC
@@ -650,6 +668,7 @@ proposition:
         relation: exactMatch
     name: somatic
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     extensions:
       - name: aliases
@@ -701,6 +720,7 @@ proposition:
         relation: exactMatch
     name: BRAF
   objectCondition:
+    type: MappableConcept
     conceptType: Disease
     id: civic.did:11
     mappings:
@@ -742,10 +762,12 @@ proposition:
             type: LiteralSequenceExpression
           type: Allele
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: liftover_to
               system: ga4gh-gks-term:allele-relation
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
         type: DefiningAlleleConstraint
@@ -994,6 +1016,7 @@ specifiedBy:
       - https://pubmed.ncbi.nlm.nih.gov/31779674/
   type: Method
 strength:
+  type: MappableConcept
   primaryCoding:
     code: strong
     system: AMP/ASCO/CAP Guidelines, 2017

--- a/tests/fixtures/civic-assertion-therapeutic-response-inline.yaml
+++ b/tests/fixtures/civic-assertion-therapeutic-response-inline.yaml
@@ -1,4 +1,5 @@
 classification:
+  type: MappableConcept
   name: Tier I
   primaryCoding:
     code: tier i
@@ -22,6 +23,7 @@ hasEvidenceLines:
         id: civic.eid:2997
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -31,6 +33,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:8
             mappings:
@@ -40,6 +43,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Lung Non-small Cell Carcinoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -78,6 +82,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: EGFR
           objectTherapy:
+            type: MappableConcept
             conceptType: Therapy
             extensions:
               - name: aliases
@@ -125,10 +130,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -315,6 +322,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000001
@@ -335,6 +343,7 @@ hasEvidenceLines:
         id: civic.eid:879
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -344,6 +353,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:30
             mappings:
@@ -353,6 +363,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Lung Adenocarcinoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -391,6 +402,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: EGFR
           objectTherapy:
+            type: MappableConcept
             conceptType: Therapy
             extensions:
               - name: aliases
@@ -438,10 +450,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -630,6 +644,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -653,6 +668,7 @@ hasEvidenceLines:
         id: civic.eid:982
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -662,6 +678,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:30
             mappings:
@@ -671,6 +688,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Lung Adenocarcinoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -709,6 +727,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: EGFR
           objectTherapy:
+            type: MappableConcept
             conceptType: Therapy
             extensions:
               - name: aliases
@@ -756,10 +775,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -949,6 +970,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -971,6 +993,7 @@ hasEvidenceLines:
         id: civic.eid:883
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -980,6 +1003,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:30
             mappings:
@@ -989,6 +1013,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Lung Adenocarcinoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -1027,6 +1052,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: EGFR
           objectTherapy:
+            type: MappableConcept
             conceptType: Therapy
             extensions:
               - name: aliases
@@ -1074,10 +1100,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -1266,6 +1294,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -1287,6 +1316,7 @@ hasEvidenceLines:
         id: civic.eid:968
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -1296,6 +1326,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:8
             mappings:
@@ -1305,6 +1336,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Lung Non-small Cell Carcinoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -1343,6 +1375,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: EGFR
           objectTherapy:
+            type: MappableConcept
             conceptType: Therapy
             extensions:
               - name: aliases
@@ -1390,10 +1423,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -1584,6 +1619,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000009
@@ -1605,6 +1641,7 @@ hasEvidenceLines:
         id: civic.eid:2629
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -1614,6 +1651,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           conditionQualifier:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:8
             mappings:
@@ -1623,6 +1661,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: Lung Non-small Cell Carcinoma
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -1661,6 +1700,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: EGFR
           objectTherapy:
+            type: MappableConcept
             conceptType: Therapy
             extensions:
               - name: aliases
@@ -1708,10 +1748,12 @@ hasEvidenceLines:
                     type: LiteralSequenceExpression
                   type: Allele
                 relations:
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: liftover_to
                       system: ga4gh-gks-term:allele-relation
-                  - primaryCoding:
+                  - type: MappableConcept
+                    primaryCoding:
                       code: translation_of
                       system: http://www.sequenceontology.org
                 type: DefiningAlleleConstraint
@@ -1901,6 +1943,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000009
@@ -1913,11 +1956,13 @@ hasEvidenceLines:
             system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
         type: Statement
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: A
         system: AMP/ASCO/CAP Guidelines, 2017
     targetProposition:
       alleleOriginQualifier:
+        type: MappableConcept
         mappings:
           - coding:
               code: SOMATIC
@@ -1927,6 +1972,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: somatic
       conditionQualifier:
+        type: MappableConcept
         conceptType: Disease
         id: civic.did:8
         mappings:
@@ -1936,6 +1982,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: Lung Non-small Cell Carcinoma
       geneContextQualifier:
+        type: MappableConcept
         conceptType: Gene
         extensions:
           - name: aliases
@@ -1974,6 +2021,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: EGFR
       objectTherapy:
+        type: MappableConcept
         conceptType: Therapy
         extensions:
           - name: aliases
@@ -2021,10 +2069,12 @@ hasEvidenceLines:
                 type: LiteralSequenceExpression
               type: Allele
             relations:
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: liftover_to
                   system: ga4gh-gks-term:allele-relation
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: translation_of
                   system: http://www.sequenceontology.org
             type: DefiningAlleleConstraint
@@ -2185,6 +2235,7 @@ hasEvidenceLines:
 id: civic.aid:6
 proposition:
   alleleOriginQualifier:
+    type: MappableConcept
     mappings:
       - coding:
           code: SOMATIC
@@ -2194,6 +2245,7 @@ proposition:
         relation: exactMatch
     name: somatic
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     extensions:
       - name: aliases
@@ -2231,6 +2283,7 @@ proposition:
         relation: exactMatch
     name: EGFR
   objectCondition:
+    type: MappableConcept
     conceptType: Disease
     id: civic.did:8
     mappings:
@@ -2270,10 +2323,12 @@ proposition:
             type: LiteralSequenceExpression
           type: Allele
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: liftover_to
               system: ga4gh-gks-term:allele-relation
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
         type: DefiningAlleleConstraint
@@ -2519,6 +2574,7 @@ specifiedBy:
       - https://pubmed.ncbi.nlm.nih.gov/31779674/
   type: Method
 strength:
+  type: MappableConcept
   primaryCoding:
     code: strong
     system: AMP/ASCO/CAP Guidelines, 2017

--- a/tests/fixtures/civic-proposition-oncogenicity.yaml
+++ b/tests/fixtures/civic-proposition-oncogenicity.yaml
@@ -1,4 +1,5 @@
 alleleOriginQualifier:
+  type: MappableConcept
   mappings:
     - coding:
         code: SOMATIC
@@ -8,6 +9,7 @@ alleleOriginQualifier:
       relation: exactMatch
   name: somatic
 geneContextQualifier:
+  type: MappableConcept
   conceptType: Gene
   extensions:
     - name: aliases
@@ -44,6 +46,7 @@ geneContextQualifier:
       relation: exactMatch
   name: RET
 objectTumorType:
+  type: MappableConcept
   conceptType: Disease
   id: civic.did:15
   mappings:
@@ -81,10 +84,12 @@ subjectVariant:
           type: LiteralSequenceExpression
         type: Allele
       relations:
-        - primaryCoding:
+        - type: MappableConcept
+          primaryCoding:
             code: liftover_to
             system: ga4gh-gks-term:allele-relation
-        - primaryCoding:
+        - type: MappableConcept
+          primaryCoding:
             code: translation_of
             system: http://www.sequenceontology.org
       type: DefiningAlleleConstraint

--- a/tests/fixtures/cohort-allele-freq-test.yaml
+++ b/tests/fixtures/cohort-allele-freq-test.yaml
@@ -48,7 +48,8 @@ subCohortFrequency:
       name: Remaining individuals Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: Remaining individuals
   - id: gnomad4:1-10120-T-G.amr
     type: CohortAlleleFrequencyStudyResult
@@ -62,7 +63,8 @@ subCohortFrequency:
       name: Admixed American Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: Admixed American
   - id: gnomad4:1-10120-T-G.fin
     type: CohortAlleleFrequencyStudyResult
@@ -76,7 +78,8 @@ subCohortFrequency:
       name: Finnish Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: Finnish
   - id: gnomad4:1-10120-T-G.ami
     type: CohortAlleleFrequencyStudyResult
@@ -90,7 +93,8 @@ subCohortFrequency:
       name: Amish Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: Amish
   - id: gnomad4:1-10120-T-G.eas
     type: CohortAlleleFrequencyStudyResult
@@ -104,7 +108,8 @@ subCohortFrequency:
       name: East Asian Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: East Asian
   - id: gnomad4:1-10120-T-G.mid
     type: CohortAlleleFrequencyStudyResult
@@ -118,7 +123,8 @@ subCohortFrequency:
       name: Middle Eastern Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: Middle Eastern
   - id: gnomad4:1-10120-T-G.sas
     type: CohortAlleleFrequencyStudyResult
@@ -132,7 +138,8 @@ subCohortFrequency:
       name: South Asian Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: South Asian
   - id: gnomad4:1-10120-T-G.asj
     type: CohortAlleleFrequencyStudyResult
@@ -146,7 +153,8 @@ subCohortFrequency:
       name: Ashkenazi Jewish Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: Ashkenazi Jewish
   - id: gnomad4:1-10120-T-G.afr
     type: CohortAlleleFrequencyStudyResult
@@ -160,7 +168,8 @@ subCohortFrequency:
       name: African/African-American Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: African/African-American
   - id: gnomad4:1-10120-T-G.nfe
     type: CohortAlleleFrequencyStudyResult
@@ -174,7 +183,8 @@ subCohortFrequency:
       name: Non-Finnish European Ancestry Group
       type: StudyGroup
       characteristics:
-      - conceptType: genetic ancestry
+      - type: MappableConcept
+        conceptType: genetic ancestry
         name: Non-Finnish European
   - id: gnomad4:1-10120-T-G.XX
     type: CohortAlleleFrequencyStudyResult
@@ -188,7 +198,8 @@ subCohortFrequency:
       name: XX
       type: StudyGroup
       characteristics:
-      - conceptType: biological sex
+      - type: MappableConcept
+        conceptType: biological sex
         name: XX
   - id: gnomad4:1-10120-T-G.XY
     type: CohortAlleleFrequencyStudyResult
@@ -202,5 +213,6 @@ subCohortFrequency:
       name: XY
       type: StudyGroup
       characteristics:
-      - conceptType: biological sex
+      - type: MappableConcept
+        conceptType: biological sex
         name: XY

--- a/tests/fixtures/conditionset-complex.yaml
+++ b/tests/fixtures/conditionset-complex.yaml
@@ -1,6 +1,8 @@
+type: ConceptSet
 membershipOperator: AND
 concepts:
-  - conceptType: Disease
+  - type: MappableConcept
+    conceptType: Disease
     id: civic.did:3387
     mappings:
       - coding:
@@ -8,8 +10,10 @@ concepts:
           system: https://disease-ontology.org/?id=
         relation: exactMatch
     name: Diffuse Astrocytoma, MYB- Or MYBL1-altered
-  - concepts:
-      - conceptType: Phenotype
+  - type: ConceptSet
+    concepts:
+      - type: MappableConcept
+        conceptType: Phenotype
         id: civic.phenotype:8121
         mappings:
           - coding:
@@ -17,7 +21,8 @@ concepts:
               system: https://hpo.jax.org/browse/term/
             relation: exactMatch
         name: Childhood onset
-      - conceptType: Phenotype
+      - type: MappableConcept
+        conceptType: Phenotype
         id: civic.phenotype:2656
         mappings:
           - coding:
@@ -25,7 +30,8 @@ concepts:
               system: https://hpo.jax.org/browse/term/
             relation: exactMatch
         name: Juvenile onset
-      - conceptType: Phenotype
+      - type: MappableConcept
+        conceptType: Phenotype
         id: civic.phenotype:2643
         mappings:
           - coding:

--- a/tests/fixtures/conditionset.yaml
+++ b/tests/fixtures/conditionset.yaml
@@ -1,13 +1,16 @@
+type: ConceptSet
 id: traitset001
 concepts:
-  - primaryCoding:
+  - type: MappableConcept
+    primaryCoding:
       code: HP:0025769
       system: http://human-phenotype-ontology.github.io/
       iris:
         - https://hpo.jax.org/browse/term/HP:0025769
         - https://www.ebi.ac.uk/ols4/ontologies/hp/classes?obo_id=HP%3A0025769
     name: Disordered formal thought process
-  - primaryCoding:
+  - type: MappableConcept
+    primaryCoding:
       code: HP:0033051
       system: http://human-phenotype-ontology.github.io/
       iris:

--- a/tests/fixtures/diagnostic-inline.yaml
+++ b/tests/fixtures/diagnostic-inline.yaml
@@ -5,6 +5,7 @@ direction: supports
 id: civic.eid:80
 proposition:
   alleleOriginQualifier:
+    type: MappableConcept
     mappings:
       - coding:
           code: SOMATIC
@@ -14,6 +15,7 @@ proposition:
         relation: exactMatch
     name: somatic
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     extensions:
       - name: aliases
@@ -65,6 +67,7 @@ proposition:
         relation: exactMatch
     name: BRAF
   objectCondition:
+    type: MappableConcept
     conceptType: Disease
     id: civic.did:156
     mappings:
@@ -106,10 +109,12 @@ proposition:
             type: LiteralSequenceExpression
           type: Allele
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: liftover_to
               system: ga4gh-gks-term:allele-relation
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
         type: DefiningAlleleConstraint
@@ -298,6 +303,7 @@ specifiedBy:
       - https://pubmed.ncbi.nlm.nih.gov/31779674/
   type: Method
 strength:
+  type: MappableConcept
   mappings:
     - coding:
         code: e000005

--- a/tests/fixtures/diagnostic-tier-iii-inline.yaml
+++ b/tests/fixtures/diagnostic-tier-iii-inline.yaml
@@ -1,4 +1,5 @@
 classification:
+  type: MappableConcept
   name: Tier III
   primaryCoding:
     code: tier iii
@@ -25,6 +26,7 @@ hasEvidenceLines:
         id: civic.eid:4846
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -34,6 +36,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -55,6 +58,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: ACVR1
           objectCondition:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:2950
             mappings:
@@ -124,6 +128,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -136,11 +141,13 @@ hasEvidenceLines:
             system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
         type: Statement
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: C
         system: AMP/ASCO/CAP Guidelines, 2017
     targetProposition:
       alleleOriginQualifier:
+        type: MappableConcept
         mappings:
           - coding:
               code: SOMATIC
@@ -150,6 +157,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: somatic
       geneContextQualifier:
+        type: MappableConcept
         conceptType: Gene
         extensions:
           - name: aliases
@@ -171,6 +179,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: ACVR1
       objectCondition:
+        type: MappableConcept
         conceptType: Disease
         id: civic.did:2950
         mappings:
@@ -210,10 +219,12 @@ hasEvidenceLines:
                 type: LiteralSequenceExpression
               type: Allele
             relations:
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: liftover_to
                   system: ga4gh-gks-term:allele-relation
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: translation_of
                   system: http://www.sequenceontology.org
             type: DefiningAlleleConstraint
@@ -361,6 +372,7 @@ hasEvidenceLines:
 id: tier3-example.civic.aid:9
 proposition:
   alleleOriginQualifier:
+    type: MappableConcept
     mappings:
       - coding:
           code: SOMATIC
@@ -370,6 +382,7 @@ proposition:
         relation: exactMatch
     name: somatic
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     extensions:
       - name: aliases
@@ -391,6 +404,7 @@ proposition:
         relation: exactMatch
     name: ACVR1
   objectCondition:
+    type: MappableConcept
     conceptType: Disease
     id: civic.did:2950
     mappings:
@@ -430,10 +444,12 @@ proposition:
             type: LiteralSequenceExpression
           type: Allele
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: liftover_to
               system: ga4gh-gks-term:allele-relation
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
         type: DefiningAlleleConstraint

--- a/tests/fixtures/diagnostic-tier-iv-inline.yaml
+++ b/tests/fixtures/diagnostic-tier-iv-inline.yaml
@@ -1,4 +1,5 @@
 classification:
+  type: MappableConcept
   name: Tier IV
   primaryCoding:
     code: tier iv
@@ -25,6 +26,7 @@ hasEvidenceLines:
         id: civic.eid:4846
         proposition:
           alleleOriginQualifier:
+            type: MappableConcept
             mappings:
               - coding:
                   code: SOMATIC
@@ -34,6 +36,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: somatic
           geneContextQualifier:
+            type: MappableConcept
             conceptType: Gene
             extensions:
               - name: aliases
@@ -55,6 +58,7 @@ hasEvidenceLines:
                 relation: exactMatch
             name: ACVR1
           objectCondition:
+            type: MappableConcept
             conceptType: Disease
             id: civic.did:2950
             mappings:
@@ -124,6 +128,7 @@ hasEvidenceLines:
               - https://pubmed.ncbi.nlm.nih.gov/31779674/
           type: Method
         strength:
+          type: MappableConcept
           mappings:
             - coding:
                 code: e000005
@@ -136,11 +141,13 @@ hasEvidenceLines:
             system: https://civic.readthedocs.io/en/latest/model/evidence/level.html
         type: Statement
     strengthOfEvidenceProvided:
+      type: MappableConcept
       primaryCoding:
         code: C
         system: AMP/ASCO/CAP Guidelines, 2017
     targetProposition:
       alleleOriginQualifier:
+        type: MappableConcept
         mappings:
           - coding:
               code: SOMATIC
@@ -150,6 +157,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: somatic
       geneContextQualifier:
+        type: MappableConcept
         conceptType: Gene
         extensions:
           - name: aliases
@@ -171,6 +179,7 @@ hasEvidenceLines:
             relation: exactMatch
         name: ACVR1
       objectCondition:
+        type: MappableConcept
         conceptType: Disease
         id: civic.did:2950
         mappings:
@@ -210,10 +219,12 @@ hasEvidenceLines:
                 type: LiteralSequenceExpression
               type: Allele
             relations:
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: liftover_to
                   system: ga4gh-gks-term:allele-relation
-              - primaryCoding:
+              - type: MappableConcept
+                primaryCoding:
                   code: translation_of
                   system: http://www.sequenceontology.org
             type: DefiningAlleleConstraint
@@ -361,6 +372,7 @@ hasEvidenceLines:
 id: tier4-example.civic.aid:9
 proposition:
   alleleOriginQualifier:
+    type: MappableConcept
     mappings:
       - coding:
           code: SOMATIC
@@ -370,6 +382,7 @@ proposition:
         relation: exactMatch
     name: somatic
   geneContextQualifier:
+    type: MappableConcept
     conceptType: Gene
     extensions:
       - name: aliases
@@ -391,6 +404,7 @@ proposition:
         relation: exactMatch
     name: ACVR1
   objectCondition:
+    type: MappableConcept
     conceptType: Disease
     id: civic.did:2950
     mappings:
@@ -430,10 +444,12 @@ proposition:
             type: LiteralSequenceExpression
           type: Allele
         relations:
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: liftover_to
               system: ga4gh-gks-term:allele-relation
-          - primaryCoding:
+          - type: MappableConcept
+            primaryCoding:
               code: translation_of
               system: http://www.sequenceontology.org
         type: DefiningAlleleConstraint

--- a/tests/fixtures/exp-func-effect-dataset.yaml
+++ b/tests/fixtures/exp-func-effect-dataset.yaml
@@ -1,6 +1,7 @@
 type: DataSet
 name: variant effect data set
 license:
+  type: MappableConcept
   primaryCoding:
     code: CC0
     system: https://spdx.org/licenses/

--- a/tests/fixtures/gnomad-dataset.yaml
+++ b/tests/fixtures/gnomad-dataset.yaml
@@ -5,6 +5,7 @@ aliases:
   - gnomAD 4
 version: 4.1.0
 license:
+  type: MappableConcept
   name: Creative Commons Zero Public Domain Dedication
   primaryCoding:
     code: CC0

--- a/tests/fixtures/prognostic-inline.yaml
+++ b/tests/fixtures/prognostic-inline.yaml
@@ -4,6 +4,7 @@ description: https://civicdb.org/evidence/82/summary
 direction: supports
 strength:
   # id: civic.evidenceLevel:B
+  type: MappableConcept
   name: Clinical evidence
   primaryCoding:
     code: B
@@ -82,6 +83,7 @@ proposition:
           system: http://www.sequenceontology.org/browser/current_release/term/
           name: missense_variant
   objectCondition:
+    type: MappableConcept
     id: civic.did:7
     conceptType: Disease
     name: Melanoma
@@ -92,6 +94,7 @@ proposition:
         relation: exactMatch
   alleleOriginQualifier: somatic
   geneContextQualifier:
+    type: MappableConcept
     id: civic.gid:5
     conceptType: Gene
     name: BRAF

--- a/tests/fixtures/sift-prediction-analysis-result.yaml
+++ b/tests/fixtures/sift-prediction-analysis-result.yaml
@@ -39,14 +39,17 @@ transcriptVariationContext:
       value: ENST00000366667.6:c.803C>T
 impactScore: 0.06
 impactScoreType:
+  type: MappableConcept
   primaryCoding:
     code: raw
     system: sift-score-types
 categoricalImpact:
+  type: MappableConcept
   primaryCoding:
     code: tolerated
     system: sift-categorical-impacts
 impactedFeatureType:
+  type: MappableConcept
   name: Protein
   primaryCoding:
     code: SO:0000104

--- a/tests/fixtures/spliceai-prediction-analysis-result.yaml
+++ b/tests/fixtures/spliceai-prediction-analysis-result.yaml
@@ -39,15 +39,18 @@ transcriptVariationContext:
       value: ENST00000366667.6:c.803C>T
 impactScore: 0.52
 impactScoreType:
+  type: MappableConcept
   primaryCoding:
     code: DS_AG
     system: spliceai-score-types
 impactedFeatureType:
+  type: MappableConcept
   name: Gene
   primaryCoding:
     code: SO:0000704
     system: Sequence Ontology
 impactedFeature:
+  type: MappableConcept
   name: AGT
   mappings:
     - coding:

--- a/tests/fixtures/therapeutic-response-inline.yaml
+++ b/tests/fixtures/therapeutic-response-inline.yaml
@@ -7,6 +7,7 @@ description: A phase III clinical trial (NCT00949650) found that median progress
 direction: supports
 strength:
   # id: civic.evidenceLevel:B
+  type: MappableConcept
   name: Clinical evidence
   primaryCoding:
     code: B
@@ -84,6 +85,7 @@ proposition:
           system: http://www.sequenceontology.org/browser/current_release/term/
           name: missense_variant
   objectTherapy:
+    type: MappableConcept
     id: civic.tid:146
     conceptType: Drug
     name: Afatinib
@@ -97,6 +99,7 @@ proposition:
           system: https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=
         relation: exactMatch
   conditionQualifier:
+    type: MappableConcept
     id: civic.did:30
     conceptType: Disease
     name: Lung Adenocarcinoma
@@ -106,6 +109,7 @@ proposition:
           system: https://www.disease-ontology.org/
         relation: exactMatch
   alleleOriginQualifier:
+    type: MappableConcept
     primaryCoding:
       code: GENO:0000882
       system: https://github.com/monarch-initiative/GENO-ontology/
@@ -113,6 +117,7 @@ proposition:
         - http://purl.obolibrary.org/obo/GENO_0000882
     name: somatic allele origin
   geneContextQualifier:
+    type: MappableConcept
     id: civic.gid:19
     conceptType: Gene
     name: EGFR

--- a/tests/fixtures/therapeuticAgent.yaml
+++ b/tests/fixtures/therapeuticAgent.yaml
@@ -1,3 +1,4 @@
+type: MappableConcept
 conceptType: Therapy
 extensions:
   - name: aliases

--- a/tests/fixtures/therapy-group.yaml
+++ b/tests/fixtures/therapy-group.yaml
@@ -1,10 +1,13 @@
+type: ConceptSet
 id: civic.theragroup:e1090
 concepts:
-  - primaryCoding:
+  - type: MappableConcept
+    primaryCoding:
       code: ncit:C1005
       system: ncit
     name: Arsenic Trioxide
-  - primaryCoding:
+  - type: MappableConcept
+    primaryCoding:
       code: C900
       system: ncit
     name: Tretinoin

--- a/tests/fixtures/tumor-variant-freq-study-result.yaml
+++ b/tests/fixtures/tumor-variant-freq-study-result.yaml
@@ -38,7 +38,8 @@ subGroupFrequency:
           name: CNS/Brain Tumor SubGroup
           type: StudyGroup
           characteristics:
-            - conceptType: Disease
+            - type: MappableConcept
+              conceptType: Disease
               name: CNS/Brain Tumors
         affectedSampleCount: 16
         totalSampleCount: 658
@@ -52,7 +53,8 @@ subGroupFrequency:
           name: Bowel Tumor SubGroup
           type: StudyGroup
           characteristics:
-            - conceptType: Disease
+            - type: MappableConcept
+              conceptType: Disease
               name: Bowel Tumors
         affectedSampleCount: 1
         totalSampleCount: 1184
@@ -74,7 +76,8 @@ subGroupFrequency:
           name: CNS/Brain Tumor SubGroup
           type: StudyGroup
           characteristics:
-            - conceptType: Disease
+            - type: MappableConcept
+              conceptType: Disease
               name: CNS/Brain Tumors
         affectedSampleCount: 6
         totalSampleCount: 658
@@ -88,7 +91,8 @@ subGroupFrequency:
           name: Bowel Tumor SubGroup
           type: StudyGroup
           characteristics:
-            - conceptType: Disease
+            - type: MappableConcept
+              conceptType: Disease
               name: Bowel Tumors
         affectedSampleCount: 1
         totalSampleCount: 1184
@@ -110,7 +114,8 @@ subGroupFrequency:
           name: Skin SubGroup
           type: StudyGroup
           characteristics:
-            - conceptType: Disease
+            - type: MappableConcept
+              conceptType: Disease
               name: Skin Tumors
         affectedSampleCount: 1
         totalSampleCount: 359

--- a/tests/fixtures/var-diagnostic-proposition.yaml
+++ b/tests/fixtures/var-diagnostic-proposition.yaml
@@ -24,13 +24,15 @@ subjectVariant:
           - syntax: hgvs.p
             value: NP_000305.3:p.Arg11Thr
       relations:
-        - primaryCoding:
+        - type: MappableConcept
+          primaryCoding:
             code: translation_of
             system: http://www.sequenceontology.org
             iris:
               - http://www.sequenceontology.org/browser/current_release/term/translation_of
 predicate: isDiagnosticInclusionCriterionFor
 objectCondition:
+  type: MappableConcept
   primaryCoding:
     code: ncit:C4872
     system: https://www.ebi.ac.uk/ols4/ontologies/ncit
@@ -38,6 +40,7 @@ objectCondition:
       - http://purl.obolibrary.org/obo/NCIT_C4872
   name: Breast Carcinoma
 geneContextQualifier:
+  type: MappableConcept
   conceptType: Gene
   name: EGFR
   primaryCoding:
@@ -46,6 +49,7 @@ geneContextQualifier:
     iris:
       - http://identifiers.org/ncbigene/1956
 alleleOriginQualifier:
+  type: MappableConcept
   primaryCoding:
     code: GENO:0000882
     system: https://github.com/monarch-initiative/GENO-ontology/

--- a/tests/fixtures/var-onco-proposition.yaml
+++ b/tests/fixtures/var-onco-proposition.yaml
@@ -23,13 +23,15 @@ subjectVariant:
           - syntax: hgvs.p
             value: NP_000305.3:p.Arg11Thr
       relations:
-        - primaryCoding:
+        - type: MappableConcept
+          primaryCoding:
             code: translation_of
             system: http://www.sequenceontology.org
             iris:
               - http://www.sequenceontology.org/browser/current_release/term/translation_of
 predicate: isOncogenicFor
 objectTumorType:
+  type: MappableConcept
   primaryCoding:
     code: ncit:C4872
     system: https://www.ebi.ac.uk/ols4/ontologies/ncit
@@ -37,6 +39,7 @@ objectTumorType:
       - http://purl.obolibrary.org/obo/NCIT_C4872
   name: Breast Carcinoma
 geneContextQualifier:
+  type: MappableConcept
   conceptType: Gene
   name: EGFR
   primaryCoding:
@@ -45,6 +48,7 @@ geneContextQualifier:
     iris:
       - http://identifiers.org/ncbigene/1956
 alleleOriginQualifier:
+  type: MappableConcept
   primaryCoding:
     code: GENO:0000882
     system: https://github.com/monarch-initiative/GENO-ontology/

--- a/tests/fixtures/var-path-proposition.yaml
+++ b/tests/fixtures/var-path-proposition.yaml
@@ -31,16 +31,19 @@ subjectVariant:
           - syntax: spdi
             value: NC_000001.11:40819438:CTCCTCCT:CTCCT
       relations:
-        - primaryCoding:
+        - type: MappableConcept
+          primaryCoding:
             code: liftover_to
             system: ga4gh-gks-term:allele-relation
-        - primaryCoding:
+        - type: MappableConcept
+          primaryCoding:
             code: transcribed_to
             system: http://www.sequenceontology.org
             iris:
               - http://www.sequenceontology.org/browser/current_release/term/transcribed_to
   name: NM_004700.4(KCNQ4):c.803CCT[1] (p.Ser269del)
 objectCondition:
+  type: MappableConcept
   id: clinvar.trait/939
   conceptType: Disease
   name: Autosomal dominant nonsyndromic hearing loss 2A
@@ -52,11 +55,13 @@ objectCondition:
       - https://www.ncbi.nlm.nih.gov/medgen/C2677637
 predicate: isCausalFor
 penetranceQualifier:
+  type: MappableConcept
   name: high penetrance
   primaryCoding:
     code: high
     system: ga4gh-gks-term:penetrance-qualifier
 alleleOriginQualifier:
+  type: MappableConcept
   primaryCoding:
     code: GENO:0000888
     system: https://github.com/monarch-initiative/GENO-ontology/
@@ -64,6 +69,7 @@ alleleOriginQualifier:
       - http://purl.obolibrary.org/obo/GENO_0000888
   name: germline allele origin
 modeOfInheritanceQualifier:
+  type: MappableConcept
   primaryCoding:
     code: HP:0000006
     system: http://human-phenotype-ontology.github.io/
@@ -72,6 +78,7 @@ modeOfInheritanceQualifier:
       - https://www.ebi.ac.uk/ols4/ontologies/hp/classes?obo_id=HP%3A0000118
   name: Autosomal dominant inheritance
 geneContextQualifier:
+  type: MappableConcept
   primaryCoding:
     code: ncbigene:9132
     system: https://identifiers.org/ncbigene/

--- a/tests/fixtures/var-prognostic-proposition.yaml
+++ b/tests/fixtures/var-prognostic-proposition.yaml
@@ -24,13 +24,15 @@ subjectVariant:
           - syntax: hgvs.p
             value: NP_000305.3:p.Arg11Thr
       relations:
-        - primaryCoding:
+        - type: MappableConcept
+          primaryCoding:
             code: translation_of
             system: http://bioportal.bioontology.org/ontologies/SO
             iris:
               - http://www.sequenceontology.org/browser/current_release/term/translation_of
 predicate: associatedWithBetterOutcomeFor
 objectCondition:
+  type: MappableConcept
   primaryCoding:
     code: ncit:C4872
     system: https://www.ebi.ac.uk/ols4/ontologies/ncit
@@ -38,6 +40,7 @@ objectCondition:
       - http://purl.obolibrary.org/obo/NCIT_C4872
   name: Breast Carcinoma
 geneContextQualifier:
+  type: MappableConcept
   conceptType: Gene
   name: EGFR
   primaryCoding:
@@ -46,6 +49,7 @@ geneContextQualifier:
     iris:
       - http://identifiers.org/ncbigene/1956
 alleleOriginQualifier:
+  type: MappableConcept
   primaryCoding:
     code: GENO:0000882
     system: https://github.com/monarch-initiative/GENO-ontology/

--- a/tests/fixtures/var-therap-resp-prop.yaml
+++ b/tests/fixtures/var-therap-resp-prop.yaml
@@ -66,6 +66,7 @@ subjectVariant:
         system: http://www.sequenceontology.org/browser/current_release/term/
         name: missense_variant
 objectTherapy:
+  type: MappableConcept
   id: civic.tid:146
   conceptType: Drug
   name: Afatinib
@@ -80,6 +81,7 @@ objectTherapy:
         system: https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=
       relation: exactMatch
 conditionQualifier:
+  type: MappableConcept
   id: civic.did:30
   conceptType: Disease
   name: Lung Adenocarcinoma
@@ -89,6 +91,7 @@ conditionQualifier:
         system: https://www.disease-ontology.org/
       relation: exactMatch
 alleleOriginQualifier:
+  type: MappableConcept
   primaryCoding:
     code: GENO:0000882
     system: https://github.com/monarch-initiative/GENO-ontology/
@@ -96,6 +99,7 @@ alleleOriginQualifier:
       - http://purl.obolibrary.org/obo/GENO_0000882
   name: somatic allele origin
 geneContextQualifier:
+  type: MappableConcept
   id: civic.gid:19
   conceptType: Gene
   name: EGFR

--- a/tests/fixtures/vep-intergenic-proposition.yaml
+++ b/tests/fixtures/vep-intergenic-proposition.yaml
@@ -19,6 +19,7 @@ subjectVariant:
     sequence: C
 predicate: "hasMolecularConsequence"
 objectConsequence:
+  type: MappableConcept
   name: intergenic_variant
   conceptType: MolecularConsequence
   primaryCoding:

--- a/tests/fixtures/vep-intronic-proposition.yaml
+++ b/tests/fixtures/vep-intronic-proposition.yaml
@@ -23,13 +23,16 @@ subjectVariant:
       value: NC_000002.11:g.7540648dup
 predicate: "hasMolecularConsequence"
 objectConsequence:
+  type: ConceptSet
   concepts:
-    - name: intron_variant
+    - type: MappableConcept
+      name: intron_variant
       conceptType: MolecularConsequence
       primaryCoding:
         code: "SO:0001627"
         system: "sequenceontology"
-    - name: non_coding_transcript_variant
+    - type: MappableConcept
+      name: non_coding_transcript_variant
       conceptType: MolecularConsequence
       primaryCoding:
         code: "SO:0001619"
@@ -49,6 +52,7 @@ objectConsequence:
   #     residueAlphabet: na
   #     type: SequenceReference
 geneContextQualifier:
+  type: MappableConcept
   primaryCoding:
     code: ENSG00000230515
     system: Ensembl-Gene

--- a/tests/fixtures/vep-transcript-proposition.yaml
+++ b/tests/fixtures/vep-transcript-proposition.yaml
@@ -22,6 +22,7 @@ subjectVariant:
       value: NC_000001.10:g.230845767G>T
 predicate: "hasMolecularConsequence"
 objectConsequence:
+  type: MappableConcept
   name: missense_variant
   conceptType: MolecularConsequence
   primaryCoding:
@@ -64,6 +65,7 @@ proteinVariationContextQualifier:
     - syntax: hgvs.p
       value: ENSP00000505981.1:p.Ala268Val
 geneContextQualifier:
+  type: MappableConcept
   name: AGT
   mappings:
     - coding:


### PR DESCRIPTION
- Point cat-vrs submodule at the 1.1.0-ballot.2026-07 branch
- Bump source schema versions and regenerate built json/rst: va-spec 1.0.1 -> 1.1.0-ballot.2026-07.1 gks-core 1.1.0 -> 1.2.0-ballot.2026-07.1 vrs 2.0.1 -> 2.1.0-ballot.2026-07.1 cat-vrs 1.0.0 -> 1.1.0-ballot.2026-07.1
- Add now-required type discriminators to test fixtures: type: MappableConcept (incl. Condition/Therapy specializations) type: ConceptSet (incl. ConditionSet/TherapyGroup)