### PR TITLE
chore: update va-spec schema $id version to v1

### DIFF
--- a/schema/va-spec/aac-2017/json/AmpAscoCapEvidenceLine
+++ b/schema/va-spec/aac-2017/json/AmpAscoCapEvidenceLine
@@ -1,25 +1,25 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/AmpAscoCapEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/aac-2017/json/AmpAscoCapEvidenceLine",
    "title": "AmpAscoCapEvidenceLine",
    "description": "Evidence line for AMP/ASCO/CAP",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/EvidenceLine"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/EvidenceLine"
       },
       {
          "properties": {
             "targetProposition": {
                "oneOf": [
                   {
-                     "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPrognosticProposition"
+                     "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPrognosticProposition"
                   },
                   {
-                     "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantDiagnosticProposition"
+                     "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantDiagnosticProposition"
                   },
                   {
-                     "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition"
+                     "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantTherapeuticResponseProposition"
                   }
                ]
             },

--- a/schema/va-spec/aac-2017/json/DiagnosticEvidenceLine
+++ b/schema/va-spec/aac-2017/json/DiagnosticEvidenceLine
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/DiagnosticEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/aac-2017/json/DiagnosticEvidenceLine",
    "title": "DiagnosticEvidenceLine",
    "description": "Diagnostic evidence line for AMP/ASCO/CAP",
    "maturity": "draft",
@@ -11,12 +11,12 @@
          {
             "allOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/AmpAscoCapEvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/v1/aac-2017/json/AmpAscoCapEvidenceLine"
                },
                {
                   "properties": {
                      "targetProposition": {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantDiagnosticProposition"
+                        "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantDiagnosticProposition"
                      }
                   },
                   "required": [

--- a/schema/va-spec/aac-2017/json/PrognosticEvidenceLine
+++ b/schema/va-spec/aac-2017/json/PrognosticEvidenceLine
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/PrognosticEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/aac-2017/json/PrognosticEvidenceLine",
    "title": "PrognosticEvidenceLine",
    "description": "Prognostic evidence line for AMP/ASCO/CAP",
    "maturity": "draft",
@@ -11,12 +11,12 @@
          {
             "allOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/AmpAscoCapEvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/v1/aac-2017/json/AmpAscoCapEvidenceLine"
                },
                {
                   "properties": {
                      "targetProposition": {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPrognosticProposition"
+                        "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPrognosticProposition"
                      }
                   },
                   "required": [

--- a/schema/va-spec/aac-2017/json/TherapeuticEvidenceLine
+++ b/schema/va-spec/aac-2017/json/TherapeuticEvidenceLine
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/TherapeuticEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/aac-2017/json/TherapeuticEvidenceLine",
    "title": "TherapeuticEvidenceLine",
    "description": "Therapeutic evidence line for AMP/ASCO/CAP",
    "maturity": "draft",
@@ -11,12 +11,12 @@
          {
             "allOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/AmpAscoCapEvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/v1/aac-2017/json/AmpAscoCapEvidenceLine"
                },
                {
                   "properties": {
                      "targetProposition": {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition"
+                        "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantTherapeuticResponseProposition"
                      }
                   },
                   "required": [

--- a/schema/va-spec/aac-2017/json/VariantClinicalSignificanceStatement
+++ b/schema/va-spec/aac-2017/json/VariantClinicalSignificanceStatement
@@ -1,17 +1,17 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/VariantClinicalSignificanceStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/aac-2017/json/VariantClinicalSignificanceStatement",
    "title": "VariantClinicalSignificanceStatement",
    "description": "A statement reporting a conclusion from a single study about the clinical significance of a variant with respect to a condition, based on interpretation of the study's results.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantClinicalSignificanceProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantClinicalSignificanceProposition"
             },
             "strength": {
                "description": "The strength of support that the Statement is determined to provide for or against the Variant Clinical Significance Proposition for the assessed variant, based on the curation and reporting conventions of the AMP/ASCO/CAP 2017 Guidelines.",
@@ -106,13 +106,13 @@
                         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/DiagnosticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/v1/aac-2017/json/DiagnosticEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/PrognosticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/v1/aac-2017/json/PrognosticEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/TherapeuticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/v1/aac-2017/json/TherapeuticEvidenceLine"
                      }
                   ]
                },
@@ -192,13 +192,13 @@
                         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/DiagnosticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/v1/aac-2017/json/DiagnosticEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/PrognosticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/v1/aac-2017/json/PrognosticEvidenceLine"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/json/TherapeuticEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/v1/aac-2017/json/TherapeuticEvidenceLine"
                      }
                   ]
                },

--- a/schema/va-spec/aac-2017/profile-source.yaml
+++ b/schema/va-spec/aac-2017/profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/aac-2017/profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/v1/aac-2017/profile-source.yaml"
 title: AAC 2017 Profiles
 description: >-
   Profiles defined to align with terminology and conventions from the Association for Molecular Pathology (AMP),
@@ -18,13 +18,13 @@ $defs:
     maturity: draft
     description: Evidence line for AMP/ASCO/CAP
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/EvidenceLine"
+      - $ref: "/ga4gh/schema/va-spec/v1/base/json/EvidenceLine"
       - properties:
           targetProposition:
             oneOf:
-              - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPrognosticProposition"
-              - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantDiagnosticProposition"
-              - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition"
+              - $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantPrognosticProposition"
+              - $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantDiagnosticProposition"
+              - $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantTherapeuticResponseProposition"
           strengthOfEvidenceProvided:
             properties:
               primaryCoding:
@@ -48,7 +48,7 @@ $defs:
           - $ref: "#/$defs/AmpAscoCapEvidenceLine"
           - properties:
               targetProposition:
-                $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPrognosticProposition"
+                $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantPrognosticProposition"
             required: [targetProposition]
         - $ref: "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
 
@@ -63,7 +63,7 @@ $defs:
           - $ref: "#/$defs/AmpAscoCapEvidenceLine"
           - properties:
               targetProposition:
-                $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantDiagnosticProposition"
+                $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantDiagnosticProposition"
             required: [targetProposition]
         - $ref: "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
 
@@ -78,7 +78,7 @@ $defs:
           - $ref: "#/$defs/AmpAscoCapEvidenceLine"
           - properties:
               targetProposition:
-                $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition"
+                $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantTherapeuticResponseProposition"
             required: [targetProposition]
         - $ref: "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
 
@@ -89,10 +89,10 @@ $defs:
       significance of a variant with respect to a condition, based on interpretation of
       the study's results.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Statement"
+      - $ref: "/ga4gh/schema/va-spec/v1/base/json/Statement"
       - properties:
           proposition:
-            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantClinicalSignificanceProposition"
+            $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantClinicalSignificanceProposition"
           strength:
             description: >-
               The strength of support that the Statement is determined to provide for or against the Variant Clinical Significance Proposition

--- a/schema/va-spec/acmg-2015/json/VariantPathogenicityEvidenceLine
+++ b/schema/va-spec/acmg-2015/json/VariantPathogenicityEvidenceLine
@@ -1,18 +1,18 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/acmg-2015/json/VariantPathogenicityEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/acmg-2015/json/VariantPathogenicityEvidenceLine",
    "title": "VariantPathogenicityEvidenceLine",
    "description": "An Evidence Line that describes how a specific type of information was interpreted as evidence for or against a variant's pathogenicity. In the ACMG Framework, evidence is assessed by determining if a specific criterion (e.g. 'PM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the default strength based on the quality and abundance of evidence.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/EvidenceLine"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/EvidenceLine"
       },
       {
          "properties": {
             "targetProposition": {
                "description": "A Variant Pathogenicity Proposition against which a specific type of evidence was assessed, to determine the strength and direction of support this evidence provides for or against the proposition's validity.",
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPathogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPathogenicityProposition"
             },
             "directionOfEvidenceProvided": {
                "type": "string",

--- a/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
+++ b/schema/va-spec/acmg-2015/json/VariantPathogenicityStatement
@@ -1,17 +1,17 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/acmg-2015/json/VariantPathogenicityStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/acmg-2015/json/VariantPathogenicityStatement",
    "title": "VariantPathogenicityStatement",
    "description": "A Statement describing the role of a variant in causing an inherited condition.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPathogenicityProposition",
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPathogenicityProposition",
                "description": "A proposition about the pathogenicity of a variant, the validity of which is assessed and reported by the Statement. A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the level of confidence/evidence supporting this claim."
             },
             "strength": {
@@ -98,7 +98,7 @@
                "items": {
                   "anyOf": [
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/acmg-2015/json/VariantPathogenicityEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/v1/acmg-2015/json/VariantPathogenicityEvidenceLine"
                      },
                      {
                         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/va-spec/acmg-2015/profile-source.yaml
+++ b/schema/va-spec/acmg-2015/profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/acmg-2015/profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/v1/acmg-2015/profile-source.yaml"
 title: ACMG 2015 Variant Pathogenicity Profiles
 description: >-
   Profiles defined to align with terminology and conventions from the American College of Medical Genetics
@@ -19,10 +19,10 @@ $defs:
     description: >-
       A Statement describing the role of a variant in causing an inherited condition.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Statement"
+      - $ref: "/ga4gh/schema/va-spec/v1/base/json/Statement"
       - properties:
           proposition:
-            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPathogenicityProposition"
+            $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantPathogenicityProposition"
             description: >-
               A proposition about the pathogenicity of a variant, the validity of which is assessed and reported by the Statement.
               A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the
@@ -104,14 +104,14 @@ $defs:
       (e.g. 'PM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the
       default strength based on the quality and abundance of evidence.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/EvidenceLine"
+      - $ref: "/ga4gh/schema/va-spec/v1/base/json/EvidenceLine"
       - properties:
           targetProposition:
             description: >-
               A Variant Pathogenicity Proposition against which a specific type of evidence was assessed, to
               determine the strength and direction of support this evidence provides for or against the
               proposition's validity.
-            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPathogenicityProposition"
+            $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantPathogenicityProposition"
           directionOfEvidenceProvided:
             type: string
             enum: ["supports", "neutral", "disputes"]

--- a/schema/va-spec/base/domain-entities-source.yaml
+++ b/schema/va-spec/base/domain-entities-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/domain-entities-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/v1/base/domain-entities-source.yaml"
 title: VA Spec Shared Domain Entity Data Structures
 strict: true
 

--- a/schema/va-spec/base/json/Agent
+++ b/schema/va-spec/base/json/Agent
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Agent",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/Agent",
    "title": "Agent",
    "type": "object",
    "maturity": "trial use",

--- a/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
+++ b/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/CohortAlleleFrequencyStudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/CohortAlleleFrequencyStudyResult",
    "title": "CohortAlleleFrequencyStudyResult",
    "maturity": "trial use",
    "type": "object",
@@ -39,7 +39,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/v1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -63,7 +63,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/v1/base/json/Document"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -94,7 +94,7 @@
          "default": "CohortAlleleFrequencyStudyResult"
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/DataSet",
          "description": "The dataset from which the CohortAlleleFrequencyStudyResult was reported.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance. If use cases for this arise we can make this attribute take an array of DataSets."
       },
@@ -123,7 +123,7 @@
          "description": "The frequency of the focusAllele in the cohort."
       },
       "cohort": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/StudyGroup",
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/StudyGroup",
          "description": "The cohort from which the frequency was derived."
       },
       "subCohortFrequency": {
@@ -131,7 +131,7 @@
          "ordered": false,
          "description": "A list of CohortAlleleFrequency objects describing subcohorts of the cohort currently being described. Subcohorts can be further subdivided into more subcohorts. This enables, for example, the description of different ancestry groups and sexes among those ancestry groups.",
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/CohortAlleleFrequencyStudyResult"
+            "$ref": "/ga4gh/schema/va-spec/v1/base/json/CohortAlleleFrequencyStudyResult"
          }
       }
    },

--- a/schema/va-spec/base/json/ComputationalVariantFunctionalImpactAnalysisResult
+++ b/schema/va-spec/base/json/ComputationalVariantFunctionalImpactAnalysisResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ComputationalVariantFunctionalImpactAnalysisResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/ComputationalVariantFunctionalImpactAnalysisResult",
    "title": "ComputationalVariantFunctionalImpactAnalysisResult",
    "maturity": "draft",
    "type": "object",
@@ -94,7 +94,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -106,12 +106,12 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/v1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of this Information Entity."
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/DataSet",
          "description": "The dataset from which the in silico scores were retrieved or derived (e.g., an Ensembl VEP annotation dataset)."
       }
    },

--- a/schema/va-spec/base/json/Condition
+++ b/schema/va-spec/base/json/Condition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Condition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/Condition",
    "title": "Condition",
    "maturity": "trial use",
    "description": "A specialization of MappableConcept representing a single condition (disease, phenotype, or trait). Allowed conceptType values include: Condition, Phenotype, Disease, Trait, Absent.",

--- a/schema/va-spec/base/json/ConditionSet
+++ b/schema/va-spec/base/json/ConditionSet
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ConditionSet",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/ConditionSet",
    "title": "ConditionSet",
    "maturity": "trial use",
    "description": "A specialization of ConceptSet representing a set of conditions (diseases, phenotypes, traits) that occur together or are related, depending on the membership operator. Concepts are restricted to Condition and ConditionSet members.",
@@ -17,10 +17,10 @@
                "items": {
                   "oneOf": [
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Condition"
+                        "$ref": "/ga4gh/schema/va-spec/v1/base/json/Condition"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ConditionSet"
+                        "$ref": "/ga4gh/schema/va-spec/v1/base/json/ConditionSet"
                      }
                   ]
                }

--- a/schema/va-spec/base/json/Contribution
+++ b/schema/va-spec/base/json/Contribution
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Contribution",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/Contribution",
    "title": "Contribution",
    "type": "object",
    "maturity": "trial use",
@@ -44,7 +44,7 @@
          "default": "Contribution"
       },
       "contributor": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Agent",
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/Agent",
          "description": "The agent that made the contribution."
       },
       "activityType": {

--- a/schema/va-spec/base/json/CustomProposition
+++ b/schema/va-spec/base/json/CustomProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/CustomProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/CustomProposition",
    "title": "CustomProposition",
    "maturity": "draft",
    "type": "object",

--- a/schema/va-spec/base/json/DataSet
+++ b/schema/va-spec/base/json/DataSet
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/DataSet",
    "title": "DataSet",
    "type": "object",
    "maturity": "trial use",
@@ -53,7 +53,7 @@
       "reportedIn": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Document"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Document"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/va-spec/base/json/Document
+++ b/schema/va-spec/base/json/Document
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Document",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/Document",
    "title": "Document",
    "type": "object",
    "maturity": "trial use",

--- a/schema/va-spec/base/json/EvidenceLine
+++ b/schema/va-spec/base/json/EvidenceLine
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/EvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/EvidenceLine",
    "title": "EvidenceLine",
    "type": "object",
    "maturity": "trial use",
@@ -40,7 +40,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/v1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -64,7 +64,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/v1/base/json/Document"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -84,34 +84,34 @@
          "description": "The possible fact against which evidence items contained in an Evidence Line were collectively evaluated, in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against a target proposition that the variant is pathogenic for a specific disease.",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/CustomProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/CustomProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ExperimentalVariantFunctionalImpactProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/ExperimentalVariantFunctionalImpactProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/GeneDiseaseValidityProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/GeneDiseaseValidityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantClinicalSignificanceProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantClinicalSignificanceProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantDiagnosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantDiagnosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantMolecularConsequenceProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantMolecularConsequenceProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantOncogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantOncogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPathogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPathogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPrognosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPrognosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantTherapeuticResponseProposition"
             }
          ]
       },
@@ -121,13 +121,13 @@
          "items": {
             "anyOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/StudyResult"
+                  "$ref": "/ga4gh/schema/va-spec/v1/base/json/StudyResult"
                },
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Statement"
+                  "$ref": "/ga4gh/schema/va-spec/v1/base/json/Statement"
                },
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/EvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/v1/base/json/EvidenceLine"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ExperimentalVariantFunctionalImpactProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/ExperimentalVariantFunctionalImpactProposition",
    "title": "ExperimentalVariantFunctionalImpactProposition",
    "maturity": "trial use",
    "type": "object",
@@ -84,7 +84,7 @@
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Document"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Document"
             },
             {
                "type": "object",

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ExperimentalVariantFunctionalImpactStudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/ExperimentalVariantFunctionalImpactStudyResult",
    "title": "ExperimentalVariantFunctionalImpactStudyResult",
    "maturity": "trial use",
    "type": "object",
@@ -40,7 +40,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/v1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -51,7 +51,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/v1/base/json/Document"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -100,7 +100,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -110,7 +110,7 @@
          "$comment": "Examples: a specific experimental protocol or data analysis specification that describes how data were generated; an evidence interpretation guideline that describes steps taken to interpret data in making a variant pathogenicity classification; a method for using electron microscopy to image cell membrane proteins. Note that this attribute captures a specific *instance* of a specification or method (e.g. the specific electron microscopy method described in https://doi.org/10.1002/cpz1.1045) - as opposed to reporting a *type* of method applied (e.g. 'Transmission Electron Microscopy')."
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/DataSet",
          "description": "The full data set that provided the reported the functional impact score.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance. If use cases for this arise we can make this attribute take an array of DataSets."
       }

--- a/schema/va-spec/base/json/GeneDiseaseValidityProposition
+++ b/schema/va-spec/base/json/GeneDiseaseValidityProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/GeneDiseaseValidityProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/GeneDiseaseValidityProposition",
    "title": "GeneDiseaseValidityProposition",
    "maturity": "draft",
    "type": "object",

--- a/schema/va-spec/base/json/Method
+++ b/schema/va-spec/base/json/Method
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Method",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/Method",
    "title": "Method",
    "type": "object",
    "maturity": "trial use",
@@ -52,7 +52,7 @@
       "reportedIn": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Document"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Document"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/va-spec/base/json/Statement
+++ b/schema/va-spec/base/json/Statement
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Statement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/Statement",
    "title": "Statement",
    "type": "object",
    "maturity": "trial use",
@@ -40,7 +40,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -53,7 +53,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/v1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -64,7 +64,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/v1/base/json/Document"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -85,34 +85,34 @@
          "$comment": "Statements put forth a Proposition that expresses some possible fact about the world, and may provide an assessment of this proposition\u2019s validity (i.e. how likely it is to be true or false based on evaluated evidence). The semantics of the Proposition are explicitly captured using subject, predicate, object, and optional qualifier attributes (SPOQ). An assessment of the Proposition\u2019s validity can optionally be captured using the Statement's direction, strength, and/or score attributes (DS).",
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/CustomProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/CustomProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ExperimentalVariantFunctionalImpactProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/ExperimentalVariantFunctionalImpactProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/GeneDiseaseValidityProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/GeneDiseaseValidityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantClinicalSignificanceProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantClinicalSignificanceProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantDiagnosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantDiagnosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantMolecularConsequenceProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantMolecularConsequenceProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantOncogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantOncogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPathogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPathogenicityProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPrognosticProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPrognosticProposition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantTherapeuticResponseProposition"
             }
          ]
       },
@@ -148,7 +148,7 @@
          "items": {
             "anyOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/EvidenceLine"
+                  "$ref": "/ga4gh/schema/va-spec/v1/base/json/EvidenceLine"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/va-spec/base/json/StudyGroup
+++ b/schema/va-spec/base/json/StudyGroup
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/StudyGroup",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/StudyGroup",
    "title": "StudyGroup",
    "type": "object",
    "maturity": "trial use",

--- a/schema/va-spec/base/json/StudyResult
+++ b/schema/va-spec/base/json/StudyResult
@@ -1,19 +1,19 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/StudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/StudyResult",
    "title": "StudyResult",
    "maturity": "trial use",
    "description": "A collection of data items from a single study that pertain to a particular subject or experimental unit in the study, along with optional provenance information describing how these data items were generated.",
    "$comment": "StudyResults provide a useful way to capture a subset of items from a study dataset that are used as evidence in generating higher order knowledge assertions about the entity that is the focus of the study result. For example, a set of allele frequency data items about a particular variant of interest selected from the complete gnomAD dataset can be reported in a StudyResult object, along with relevant provenance information, so they can be referenced together as evidence for a higher-order assertion about the variant's pathogenicity. Note that a 'dataItem' attribute, which would hold an array of data selected for inclusion in the StudyResult, is not included in this version of the StudyResult class. Profiles that extend this core class can define data type specific attributes to capture such information (e.g.'focusAlleleCount', 'focusAlleleFrequency', and 'locusAlleleCount' attributes in a CohortAlleleFrequencyStudyResult profile). But technical limitations in our current profiling framework tooling forced us to omit a core 'dataItems attribute that these specialized attributes would conceptually extend.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/CohortAlleleFrequencyStudyResult"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/CohortAlleleFrequencyStudyResult"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ComputationalVariantFunctionalImpactAnalysisResult"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/ComputationalVariantFunctionalImpactAnalysisResult"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ExperimentalVariantFunctionalImpactStudyResult"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/ExperimentalVariantFunctionalImpactStudyResult"
       }
    ]
 }

--- a/schema/va-spec/base/json/SubjectVariantProposition
+++ b/schema/va-spec/base/json/SubjectVariantProposition
@@ -1,30 +1,30 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/SubjectVariantProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/SubjectVariantProposition",
    "title": "SubjectVariantProposition",
    "maturity": "trial use",
    "description": "A Proposition that has a variant as the subject.",
    "oneOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ExperimentalVariantFunctionalImpactProposition"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/ExperimentalVariantFunctionalImpactProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantClinicalSignificanceProposition"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantClinicalSignificanceProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantDiagnosticProposition"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantDiagnosticProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantOncogenicityProposition"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantOncogenicityProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPathogenicityProposition"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPathogenicityProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPrognosticProposition"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantPrognosticProposition"
       },
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantTherapeuticResponseProposition"
       }
    ]
 }

--- a/schema/va-spec/base/json/Therapy
+++ b/schema/va-spec/base/json/Therapy
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Therapy",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/Therapy",
    "title": "Therapy",
    "maturity": "trial use",
    "description": "A specialization of MappableConcept representing an individual therapy (drug, procedure, behavioral intervention, etc.). Allowed conceptType values include: Therapy, Absent, Drug, Procedure, Behavioral Intervention.",

--- a/schema/va-spec/base/json/TherapyGroup
+++ b/schema/va-spec/base/json/TherapyGroup
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/TherapyGroup",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/TherapyGroup",
    "title": "TherapyGroup",
    "maturity": "trial use",
    "description": "A specialization of ConceptSet representing a group of two or more therapies that are applied in combination to a single patient/subject, or applied individually to a different subset of participants in a research study. Concepts are restricted to Therapy and TherapyGroup members.",
@@ -17,10 +17,10 @@
                "items": {
                   "oneOf": [
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Therapy"
+                        "$ref": "/ga4gh/schema/va-spec/v1/base/json/Therapy"
                      },
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/TherapyGroup"
+                        "$ref": "/ga4gh/schema/va-spec/v1/base/json/TherapyGroup"
                      }
                   ]
                }

--- a/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
+++ b/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/TumorVariantFrequencyStudyResult",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/TumorVariantFrequencyStudyResult",
    "title": "TumorVariantFrequencyStudyResult",
    "maturity": "draft",
    "type": "object",
@@ -39,7 +39,7 @@
       "specifiedBy": {
          "oneOf": [
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Method"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Method"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -52,7 +52,7 @@
          "type": "array",
          "ordered": true,
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Contribution"
+            "$ref": "/ga4gh/schema/va-spec/v1/base/json/Contribution"
          },
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of an Information Entity.",
          "$comment": "This attribute holds one or more Contribution objects, which provide structured descriptions of a contribution made to the Information Entity by a particular agent."
@@ -63,7 +63,7 @@
          "items": {
             "oneOf": [
                {
-                  "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Document"
+                  "$ref": "/ga4gh/schema/va-spec/v1/base/json/Document"
                },
                {
                   "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
@@ -94,7 +94,7 @@
          "default": "TumorVariantFrequencyStudyResult"
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet",
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/DataSet",
          "description": "The dataset from which data in the Tumor Variant Frequency Study Result was taken.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance. If use cases for this arise we can make this attribute take an array of DataSets."
       },
@@ -126,7 +126,7 @@
          "description": "The frequency of tumor samples that include the focus variant in the sample group."
       },
       "sampleGroup": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/StudyGroup",
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/StudyGroup",
          "description": "The set of samples about which the frequency data was generated."
       },
       "subGroupFrequency": {
@@ -134,7 +134,7 @@
          "ordered": false,
          "description": "A list of Tumor Variant Frequency Study Result objects describing variant frequency in different subsets of larger sample group described in the root Study Result. Subgroups can be further subdivided into more subgroups. This enables, for example, further breakdown of frequency measures in sample groups with a narrower categorical variant than the root focus variant, or sample groups with a more specific tumor type.",
          "items": {
-            "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/TumorVariantFrequencyStudyResult"
+            "$ref": "/ga4gh/schema/va-spec/v1/base/json/TumorVariantFrequencyStudyResult"
          }
       }
    },

--- a/schema/va-spec/base/json/VariantClinicalSignificanceProposition
+++ b/schema/va-spec/base/json/VariantClinicalSignificanceProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantClinicalSignificanceProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/VariantClinicalSignificanceProposition",
    "title": "VariantClinicalSignificanceProposition",
    "type": "object",
    "maturity": "draft",
@@ -94,10 +94,10 @@
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/ConditionSet"
             }
          ],
          "description": "The condition that is evaluated.",

--- a/schema/va-spec/base/json/VariantDiagnosticProposition
+++ b/schema/va-spec/base/json/VariantDiagnosticProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantDiagnosticProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/VariantDiagnosticProposition",
    "title": "VariantDiagnosticProposition",
    "type": "object",
    "maturity": "trial use",
@@ -96,10 +96,10 @@
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/ConditionSet"
             }
          ],
          "description": "The disease that is evaluated for diagnosis.",

--- a/schema/va-spec/base/json/VariantMolecularConsequenceProposition
+++ b/schema/va-spec/base/json/VariantMolecularConsequenceProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantMolecularConsequenceProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/VariantMolecularConsequenceProposition",
    "title": "VariantMolecularConsequenceProposition",
    "maturity": "draft",
    "type": "object",

--- a/schema/va-spec/base/json/VariantOncogenicityProposition
+++ b/schema/va-spec/base/json/VariantOncogenicityProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantOncogenicityProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/VariantOncogenicityProposition",
    "title": "VariantOncogenicityProposition",
    "maturity": "trial use",
    "type": "object",
@@ -94,10 +94,10 @@
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/ConditionSet"
             }
          ],
          "description": "The tumor type for which the variant impact is evaluated.",

--- a/schema/va-spec/base/json/VariantPathogenicityProposition
+++ b/schema/va-spec/base/json/VariantPathogenicityProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPathogenicityProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/VariantPathogenicityProposition",
    "title": "VariantPathogenicityProposition",
    "maturity": "trial use",
    "type": "object",
@@ -94,10 +94,10 @@
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/ConditionSet"
             }
          ],
          "description": "The Condition or ConditionSetfor which the variant impact is stated.",

--- a/schema/va-spec/base/json/VariantPrognosticProposition
+++ b/schema/va-spec/base/json/VariantPrognosticProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantPrognosticProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/VariantPrognosticProposition",
    "title": "VariantPrognosticProposition",
    "type": "object",
    "maturity": "trial use",
@@ -96,10 +96,10 @@
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/ConditionSet"
             }
          ],
          "description": "The disease that is evaluated for outcome.",

--- a/schema/va-spec/base/json/VariantTherapeuticResponseProposition
+++ b/schema/va-spec/base/json/VariantTherapeuticResponseProposition
@@ -1,6 +1,6 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/base/json/VariantTherapeuticResponseProposition",
    "title": "VariantTherapeuticResponseProposition",
    "maturity": "trial use",
    "type": "object",
@@ -96,10 +96,10 @@
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Therapy"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Therapy"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/TherapyGroup"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/TherapyGroup"
             }
          ],
          "description": "A drug administration or other therapeutic procedure that the neoplasm is intended to respond to.",
@@ -111,10 +111,10 @@
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Condition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/Condition"
             },
             {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/ConditionSet"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/ConditionSet"
             }
          ],
          "description": "Reports the disease context in which the variant's association with therapeutic sensitivity or resistance is evaluated. Note that this is a required qualifier in therapeutic response propositions."

--- a/schema/va-spec/base/va-core-source.yaml
+++ b/schema/va-spec/base/va-core-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/va-spec-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/v1/base/va-spec-source.yaml"
 title: VA Specification Core classes
 strict: true
 

--- a/schema/va-spec/ccv-2022/json/VariantOncogenicityEvidenceLine
+++ b/schema/va-spec/ccv-2022/json/VariantOncogenicityEvidenceLine
@@ -1,18 +1,18 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/ccv-2022/json/VariantOncogenicityEvidenceLine",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/ccv-2022/json/VariantOncogenicityEvidenceLine",
    "title": "VariantOncogenicityEvidenceLine",
    "description": "An Evidence Line that describes how evidence for a variant was interpreted to determine if a specific CCV 2022 criterion code is met, and the strength that evidence this provides for or against the variant's oncogenicity. An Evidence Line that describes how a specific type of information was interpreted as evidence for or against a variant's oncogenicity. In the CCV Framework, evidence is assessed by determining if a specific criterion (e.g. 'OM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the default strength based on the quality and abundance of evidence.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/EvidenceLine"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/EvidenceLine"
       },
       {
          "properties": {
             "targetProposition": {
                "description": "A Variant Oncogenicity Proposition against which a specific type of evidence was assessed, to determine the strength and direction of support this evidence provides for or against the proposition's validity.",
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantOncogenicityProposition"
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantOncogenicityProposition"
             },
             "directionOfEvidenceProvided": {
                "type": "string",

--- a/schema/va-spec/ccv-2022/json/VariantOncogenicityStatement
+++ b/schema/va-spec/ccv-2022/json/VariantOncogenicityStatement
@@ -1,17 +1,17 @@
 {
    "$schema": "https://json-schema.org/draft/2020-12/schema",
-   "$id": "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/ccv-2022/json/VariantOncogenicityStatement",
+   "$id": "https://w3id.org/ga4gh/schema/va-spec/v1/ccv-2022/json/VariantOncogenicityStatement",
    "title": "VariantOncogenicityStatement",
    "description": "A statement reporting a conclusion from a single study about whether a variant is associated with oncogenicity (positive or negative) - based on interpretation of the study's results.",
    "maturity": "draft",
    "allOf": [
       {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Statement"
+         "$ref": "/ga4gh/schema/va-spec/v1/base/json/Statement"
       },
       {
          "properties": {
             "proposition": {
-               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantOncogenicityProposition",
+               "$ref": "/ga4gh/schema/va-spec/v1/base/json/VariantOncogenicityProposition",
                "description": "A proposition about the oncogenicity of a variant, for which the study provides evidence. The validity of this proposition, and the level of confidence/evidence supporting it, may be assessed and reported by the Statement."
             },
             "strength": {
@@ -74,7 +74,7 @@
                "items": {
                   "anyOf": [
                      {
-                        "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/ccv-2022/json/VariantOncogenicityEvidenceLine"
+                        "$ref": "/ga4gh/schema/va-spec/v1/ccv-2022/json/VariantOncogenicityEvidenceLine"
                      },
                      {
                         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"

--- a/schema/va-spec/ccv-2022/profile-source.yaml
+++ b/schema/va-spec/ccv-2022/profile-source.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://w3id.org/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/ccv-2022/profile-source.yaml"
+$id: "https://w3id.org/ga4gh/schema/va-spec/v1/ccv-2022/profile-source.yaml"
 title: CCV 2022 Variant Oncogenicity Profiles
 description: >-
   Profiles defined to align with terminology and conventions from the Clinical Genome Resource (ClinGen),
@@ -21,10 +21,10 @@ $defs:
       is associated with oncogenicity (positive or negative) - based on interpretation of the study's
       results.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Statement"
+      - $ref: "/ga4gh/schema/va-spec/v1/base/json/Statement"
       - properties:
           proposition:
-            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantOncogenicityProposition"
+            $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantOncogenicityProposition"
             description: >-
               A proposition about the oncogenicity of a variant, for which the study provides evidence.
               The validity of this proposition, and the level of confidence/evidence supporting it,
@@ -88,14 +88,14 @@ $defs:
       (e.g. 'OM2') with a default strength (e.g. 'moderate') is 'met' or 'not met', and in some cases adjusting the
       default strength based on the quality and abundance of evidence.
     allOf:
-      - $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/EvidenceLine"
+      - $ref: "/ga4gh/schema/va-spec/v1/base/json/EvidenceLine"
       - properties:
           targetProposition:
             description: >-
               A Variant Oncogenicity Proposition against which a specific type of evidence was assessed, to
               determine the strength and direction of support this evidence provides for or against the
               proposition's validity.
-            $ref: "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantOncogenicityProposition"
+            $ref: "/ga4gh/schema/va-spec/v1/base/json/VariantOncogenicityProposition"
           directionOfEvidenceProvided:
             type: string
             enum: ["supports", "neutral", "disputes"]


### PR DESCRIPTION
## Summary
- Replaces the version segment `1.1.0-ballot.2026-07.2` with `v1` in all va-spec `*-source.yaml` `$id` and `$ref` values
- Regenerates the built JSON schema files to match

## Notes
- The cat-vrs curie prefix in `va-core-source.yaml` (`cat-vrs/1.1.0-ballot.2026-07.1`) is intentionally left unchanged — it references the cat-vrs submodule version, not va-spec.
- No example tests or fixtures required changes: fixtures/examples don't embed schema versions, and the test harness (`tests/config.py`) strips the version segment during `$ref` resolution. Full suite passes (4 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)