### PR TITLE
Resolve #435 and #437: CustomProposition ConceptSet + iriReference consistency

### DIFF
--- a/docs/source/github_links.txt
+++ b/docs/source/github_links.txt
@@ -37,6 +37,8 @@ prognostic_proposition_source_yaml = schema/va-spec/base/va-core-source.yaml#L93
 prognostic_proposition_json_schema = schema/va-spec/base/json/VariantPrognosticProposition
 experimental_variant_functional_impact_proposition_source_yaml = schema/va-spec/base/va-core-source.yaml#L749
 experimental_variant_functional_impact_proposition_json_schema = schema/va-spec/base/json/ExperimentalVariantFunctionalImpactProposition
+custom_proposition_source_yaml = schema/va-spec/base/va-core-source.yaml#L242
+custom_proposition_json_schema = schema/va-spec/base/json/CustomProposition
 
 cohort_allele_frequency_study_result_source_yaml = schema/va-spec/base/va-core-source.yaml#L1004
 cohort_allele_frequency_study_result_json_schema = schema/va-spec/base/json/CohortAlleleFrequencyStudyResult

--- a/docs/source/va-standard-profiles/base-profiles/proposition-profiles.rst
+++ b/docs/source/va-standard-profiles/base-profiles/proposition-profiles.rst
@@ -144,3 +144,13 @@ Custom Proposition
 ##################
 
 .. include::  ../../def/va-spec/CustomProposition.rst
+
+
+**Artifacts**
+ - |custom_proposition_source_yaml|
+ - |custom_proposition_json_schema|
+
+**Custom Proposition Semantics**
+ - The ``CustomProposition`` class lets data providers define their own proposition types before they are formally profiled in the VA-Spec, using the generic ``subject``, ``predicate``, ``object`` structure of the core :ref:`Proposition<Proposition>`.
+ - The ``customPropositionType`` attribute distinguishes one kind of CustomProposition from another - playing the role that ``type`` plays for standard Proposition subclasses (e.g. ClinVar's *"ClinvarDrugResponseProposition"*, which asserts a proposition such as *"a CFTR variant has a drug response for ivacaftor"*).
+ - ``CustomProposition`` is at a **draft** maturity level and may change significantly in future releases.

--- a/docs/source/va-standard-profiles/base-profiles/proposition-profiles.rst
+++ b/docs/source/va-standard-profiles/base-profiles/proposition-profiles.rst
@@ -153,4 +153,3 @@ Custom Proposition
 **Custom Proposition Semantics**
  - The ``CustomProposition`` class lets data providers define their own proposition types before they are formally profiled in the VA-Spec, using the generic ``subject``, ``predicate``, ``object`` structure of the core :ref:`Proposition<Proposition>`.
  - The ``customPropositionType`` attribute distinguishes one kind of CustomProposition from another - playing the role that ``type`` plays for standard Proposition subclasses (e.g. ClinVar's *"ClinvarDrugResponseProposition"*, which asserts a proposition such as *"a CFTR variant has a drug response for ivacaftor"*).
- - ``CustomProposition`` is at a **draft** maturity level and may change significantly in future releases.

--- a/schema/va-spec/base/def/CohortAlleleFrequencyStudyResult.rst
+++ b/schema/va-spec/base/def/CohortAlleleFrequencyStudyResult.rst
@@ -96,7 +96,7 @@ Some CohortAlleleFrequencyStudyResult attributes are inherited from :ref:`StudyR
       - MUST be "CohortAlleleFrequencyStudyResult".
    *  - sourceDataSet
       -
-      - :ref:`DataSet`
+      - :ref:`DataSet` | :ref:`iriReference`
       - 0..1
       - The dataset from which the CohortAlleleFrequencyStudyResult was reported.
    *  - focusAllele
@@ -121,7 +121,7 @@ Some CohortAlleleFrequencyStudyResult attributes are inherited from :ref:`StudyR
       - The frequency of the focusAllele in the cohort.
    *  - cohort
       -
-      - :ref:`StudyGroup`
+      - :ref:`StudyGroup` | :ref:`iriReference`
       - 1..1
       - The cohort from which the frequency was derived.
    *  - subCohortFrequency

--- a/schema/va-spec/base/def/ComputationalVariantFunctionalImpactAnalysisResult.rst
+++ b/schema/va-spec/base/def/ComputationalVariantFunctionalImpactAnalysisResult.rst
@@ -83,6 +83,6 @@ An AnalysisResult that reports the output of a single in silico tool's analysis 
       - Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of this Information Entity.
    *  - sourceDataSet
       -
-      - :ref:`DataSet`
+      - :ref:`DataSet` | :ref:`iriReference`
       - 0..1
       - The dataset from which the in silico scores were retrieved or derived (e.g., an Ensembl VEP annotation dataset).

--- a/schema/va-spec/base/def/ComputationalVariantFunctionalImpactAnalysisResult.rst
+++ b/schema/va-spec/base/def/ComputationalVariantFunctionalImpactAnalysisResult.rst
@@ -47,17 +47,17 @@ An AnalysisResult that reports the output of a single in silico tool's analysis 
       - A descriptor indicating what the score represents (e.g., 'SIFT impact score', 'CADD Phred-scaled impact score').
    *  - categoricalImpact
       -
-      - :ref:`iriReference` | :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - The categorical interpretation derived from the score by the in silico tool (e.g., 'tolerated', 'benign', 'pathogenic').
    *  - impactedFeatureType
       -
-      - :ref:`iriReference` | :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - A descriptor indicating the type of feature for which the focus variant has a predicted impact
    *  - impactedFeature
       -
-      - :ref:`iriReference` | :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - The specific feature for which the focus variant has a predicted impact
    *  - ancillaryResults
@@ -70,7 +70,7 @@ An AnalysisResult that reports the output of a single in silico tool's analysis 
       - An object in which implementers can define custom fields to capture additional scores or outputs produced by the in silico tool beyond the primary score. For example, CADD reports both a raw score and a Phred-scaled score; the primary score field would hold one, and ancillaryResults would hold the other.
    *  - specifiedBy
       -
-      - :ref:`iriReference` | :ref:`Method`
+      - :ref:`Method` | :ref:`iriReference`
       - 0..1
       - The in silico method or algorithm that was applied to generate the reported score(s).
    *  - contributions

--- a/schema/va-spec/base/def/Contribution.rst
+++ b/schema/va-spec/base/def/Contribution.rst
@@ -59,7 +59,7 @@ Some Contribution attributes are inherited from :ref:`gks-core:Entity`.
       - MUST be "Contribution".
    *  - contributor
       -
-      - :ref:`Agent`
+      - :ref:`Agent` | :ref:`iriReference`
       - 0..1
       - The agent that made the contribution.
    *  - activityType

--- a/schema/va-spec/base/def/CustomProposition.rst
+++ b/schema/va-spec/base/def/CustomProposition.rst
@@ -64,9 +64,9 @@ Some CustomProposition attributes are inherited from :ref:`Proposition`.
       - A user-defined subtype that distinguishes one kind of CustomProposition from another. Because all CustomPropositions share the same 'type' value ("CustomProposition"), this attribute plays the role that 'type' plays for standard Proposition subclasses - allowing consumers to discern the specific type of possible fact a given CustomProposition represents (e.g. "GeneDiseaseValidityProposition").
    *  - subject
       -
-      - :ref:`MolecularVariation` | :ref:`CategoricalVariant` | :ref:`MappableConcept` | :ref:`iriReference`
+      - :ref:`Variation` | :ref:`CategoricalVariant` | :ref:`MappableConcept` | :ref:`ConceptSet` | :ref:`iriReference`
       - 1..1
-      - A custom entity or concept that is the subject of the Proposition.
+      - A variant or concept that is the subject of the Proposition.
    *  - predicate
       -
       - string
@@ -74,9 +74,9 @@ Some CustomProposition attributes are inherited from :ref:`Proposition`.
       - A custom predicate that describes the relationship between the subject and object of the Proposition.
    *  - object
       -
-      - :ref:`iriReference` | :ref:`MappableConcept`
+      - :ref:`Variation` | :ref:`CategoricalVariant` | :ref:`MappableConcept` | :ref:`ConceptSet` | :ref:`iriReference`
       - 1..1
-      - A custom entity or concept that is the object of the Proposition.
+      - A variant or concept that is the object of the Proposition.
    *  - qualifiers
       -
                         .. raw:: html

--- a/schema/va-spec/base/def/CustomProposition.rst
+++ b/schema/va-spec/base/def/CustomProposition.rst
@@ -61,7 +61,7 @@ Some CustomProposition attributes are inherited from :ref:`Proposition`.
       -
       - string
       - 1..1
-      - A user-defined subtype that distinguishes one kind of CustomProposition from another. Because all CustomPropositions share the same 'type' value ("CustomProposition"), this attribute plays the role that 'type' plays for standard Proposition subclasses - allowing consumers to discern the specific type of possible fact a given CustomProposition represents (e.g. "GeneDiseaseValidityProposition").
+      - A user-defined subtype that distinguishes one kind of CustomProposition from another. Because all CustomPropositions share the same 'type' value ("CustomProposition"), this attribute plays the role that 'type' plays for standard Proposition subclasses - allowing consumers to discern the specific type of possible fact a given CustomProposition represents (e.g. "ClinvarDrugResponseProposition").
    *  - subject
       -
       - :ref:`Variation` | :ref:`CategoricalVariant` | :ref:`MappableConcept` | :ref:`ConceptSet` | :ref:`iriReference`

--- a/schema/va-spec/base/def/DataSet.rst
+++ b/schema/va-spec/base/def/DataSet.rst
@@ -82,6 +82,6 @@ Some DataSet attributes are inherited from :ref:`gks-core:Entity`.
       - The version of the DataSet, as assigned by its creator.
    *  - license
       -
-      - :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - A specific license that dictates legal permissions for how a data set can be used (by whom, where, for what purposes, with what additional requirements, etc.)

--- a/schema/va-spec/base/def/EvidenceLine.rst
+++ b/schema/va-spec/base/def/EvidenceLine.rst
@@ -80,7 +80,7 @@ Some EvidenceLine attributes are inherited from :ref:`InformationEntity`.
       - MUST be "EvidenceLine".
    *  - targetProposition
       -
-      - :ref:`Proposition`
+      - :ref:`Proposition` | :ref:`iriReference`
       - 0..1
       - The possible fact against which evidence items contained in an Evidence Line were collectively evaluated, in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against a target proposition that the variant is pathogenic for a specific disease.
    *  - hasEvidenceItems

--- a/schema/va-spec/base/def/EvidenceLine.rst
+++ b/schema/va-spec/base/def/EvidenceLine.rst
@@ -98,7 +98,7 @@ Some EvidenceLine attributes are inherited from :ref:`InformationEntity`.
       - The direction of support that the Evidence Line is determined to provide toward its target Proposition (supports, disputes, neutral)
    *  - strengthOfEvidenceProvided
       -
-      - :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - The strength of support that an Evidence Line is determined to provide for or against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided value.
    *  - scoreOfEvidenceProvided
@@ -108,6 +108,6 @@ Some EvidenceLine attributes are inherited from :ref:`InformationEntity`.
       - A quantitative score indicating the strength of support that an Evidence Line is determined to provide for or against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided value.
    *  - evidenceOutcome
       -
-      - :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - A term summarizing the overall outcome of the evidence assessment represented by the Evidence Line, in terms of the direction and strength of support it provides for or against the target Proposition.

--- a/schema/va-spec/base/def/ExperimentalVariantFunctionalImpactProposition.rst
+++ b/schema/va-spec/base/def/ExperimentalVariantFunctionalImpactProposition.rst
@@ -69,7 +69,7 @@ Some ExperimentalVariantFunctionalImpactProposition attributes are inherited fro
       - The relationship the Proposition describes between the subject variant and object sequence feature whose function it may alter. MUST be "impactsFunctionOf".
    *  - objectSequenceFeature
       -
-      - :ref:`iriReference` | :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 1..1
       - The sequence feature (typically a gene or gene product) on whose function the impact of the subject variant is reported.
    *  - experimentalContextQualifier

--- a/schema/va-spec/base/def/ExperimentalVariantFunctionalImpactStudyResult.rst
+++ b/schema/va-spec/base/def/ExperimentalVariantFunctionalImpactStudyResult.rst
@@ -106,6 +106,6 @@ Some ExperimentalVariantFunctionalImpactStudyResult attributes are inherited fro
       - The assay that was performed to generate the reported functional impact score.
    *  - sourceDataSet
       -
-      - :ref:`DataSet`
+      - :ref:`DataSet` | :ref:`iriReference`
       - 0..1
       - The full data set that provided the reported the functional impact score.

--- a/schema/va-spec/base/def/GeneticContextVariantProposition.rst
+++ b/schema/va-spec/base/def/GeneticContextVariantProposition.rst
@@ -64,7 +64,7 @@ Some GeneticContextVariantProposition attributes are inherited from :ref:`Subjec
       - The relationship declared to hold between the subject and the object of the Proposition.
    *  - object
       -
-      - object
+      - :ref:`Entity` | :ref:`iriReference`
       - 1..1
       - An Entity or concept that is related to the subject of a Proposition via its predicate.
    *  - subjectVariant

--- a/schema/va-spec/base/def/GeneticContextVariantProposition.rst
+++ b/schema/va-spec/base/def/GeneticContextVariantProposition.rst
@@ -64,7 +64,7 @@ Some GeneticContextVariantProposition attributes are inherited from :ref:`Subjec
       - The relationship declared to hold between the subject and the object of the Proposition.
    *  - object
       -
-      - :ref:`Entity` | :ref:`iriReference`
+      - :ref:`Entity` | :ref:`ConceptSet` | :ref:`iriReference`
       - 1..1
       - An Entity or concept that is related to the subject of a Proposition via its predicate.
    *  - subjectVariant

--- a/schema/va-spec/base/def/Proposition.rst
+++ b/schema/va-spec/base/def/Proposition.rst
@@ -59,7 +59,7 @@ Some Proposition attributes are inherited from :ref:`gks-core:Entity`.
       - A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.
    *  - subject
       -
-      - :ref:`Entity` | :ref:`iriReference`
+      - :ref:`Entity` | :ref:`ConceptSet` | :ref:`iriReference`
       - 1..1
       - The Entity or concept about which the Proposition is made.
    *  - predicate
@@ -69,6 +69,6 @@ Some Proposition attributes are inherited from :ref:`gks-core:Entity`.
       - The relationship declared to hold between the subject and the object of the Proposition.
    *  - object
       -
-      - :ref:`Entity` | :ref:`iriReference`
+      - :ref:`Entity` | :ref:`ConceptSet` | :ref:`iriReference`
       - 1..1
       - An Entity or concept that is related to the subject of a Proposition via its predicate.

--- a/schema/va-spec/base/def/Proposition.rst
+++ b/schema/va-spec/base/def/Proposition.rst
@@ -59,7 +59,7 @@ Some Proposition attributes are inherited from :ref:`gks-core:Entity`.
       - A list of extensions to the Entity, that allow for capture of information not directly supported by elements defined in the model.
    *  - subject
       -
-      - object
+      - :ref:`Entity` | :ref:`iriReference`
       - 1..1
       - The Entity or concept about which the Proposition is made.
    *  - predicate
@@ -69,6 +69,6 @@ Some Proposition attributes are inherited from :ref:`gks-core:Entity`.
       - The relationship declared to hold between the subject and the object of the Proposition.
    *  - object
       -
-      - object
+      - :ref:`Entity` | :ref:`iriReference`
       - 1..1
       - An Entity or concept that is related to the subject of a Proposition via its predicate.

--- a/schema/va-spec/base/def/Statement.rst
+++ b/schema/va-spec/base/def/Statement.rst
@@ -80,7 +80,7 @@ Some Statement attributes are inherited from :ref:`InformationEntity`.
       - MUST be "Statement".
    *  - proposition
       -
-      - :ref:`Proposition`
+      - :ref:`Proposition` | :ref:`iriReference`
       - 1..1
       - A possible fact, the validity of which is assessed and reported by the Statement. A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the level of confidence/evidence supporting this claim.
    *  - direction
@@ -90,7 +90,7 @@ Some Statement attributes are inherited from :ref:`InformationEntity`.
       - A term indicating whether the Statement supports, disputes, or remains neutral w.r.t. the validity of the Proposition it evaluates.
    *  - strength
       -
-      - :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - A term used to report the strength of a Proposition's assessment in the direction indicated (i.e. how strongly supported or disputed the Proposition is believed to be).  Implementers may choose to frame a strength assessment in terms of how *confident* an agent is that the Proposition is true or false, or in terms of the *strength of all evidence* they believe supports or disputes it.
    *  - score
@@ -103,7 +103,7 @@ Some Statement attributes are inherited from :ref:`InformationEntity`.
       - A quantitative score that indicates the strength of a Proposition's assessment in the direction indicated (i.e. how strongly supported or disputed the Proposition is believed to be). Depending on its implementation, a score may reflect how *confident* that agent is that the Proposition is true or false, or the *strength of evidence* they believe supports or disputes it. Instructions for how to interpret the meaning of a given score may be gleaned from the method or document referenced in 'specifiedBy' attribute.
    *  - classification
       -
-      - :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's Proposition, in terms of a classification of its subject.
    *  - hasEvidenceLines

--- a/schema/va-spec/base/def/StudyGroup.rst
+++ b/schema/va-spec/base/def/StudyGroup.rst
@@ -70,6 +70,6 @@ Some StudyGroup attributes are inherited from :ref:`gks-core:Entity`.
                         .. raw:: html
 
                             <span style="background-color: #B2DFEE; color: black; padding: 2px 6px; border: 1px solid black; border-radius: 3px; font-weight: bold; display: inline-block; margin-bottom: 5px;" title="Unordered">&#8942;</span>
-      - :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..m
       - A feature or role shared by all members of the StudyGroup, representing a criterion for membership in the group.

--- a/schema/va-spec/base/def/StudyResult.rst
+++ b/schema/va-spec/base/def/StudyResult.rst
@@ -80,7 +80,7 @@ Some StudyResult attributes are inherited from :ref:`InformationEntity`.
       - A document in which the the Information Entity is reported.
    *  - focus
       -
-      - :ref:`Entity` | :ref:`iriReference`
+      - :ref:`Entity` | :ref:`ConceptSet` | :ref:`iriReference`
       - 1..1
       - The specific participant, subject or experimental unit in a Study that data included in the StudyResult object is about - e.g. a particular variant in a population allele frequency dataset like ExAC or gnomAD.
    *  - sourceDataSet

--- a/schema/va-spec/base/def/StudyResult.rst
+++ b/schema/va-spec/base/def/StudyResult.rst
@@ -85,7 +85,7 @@ Some StudyResult attributes are inherited from :ref:`InformationEntity`.
       - The specific participant, subject or experimental unit in a Study that data included in the StudyResult object is about - e.g. a particular variant in a population allele frequency dataset like ExAC or gnomAD.
    *  - sourceDataSet
       -
-      - :ref:`DataSet`
+      - :ref:`DataSet` | :ref:`iriReference`
       - 0..1
       - A larger DataSet from which the data included in the StudyResult was taken or derived.
    *  - ancillaryResults

--- a/schema/va-spec/base/def/SubjectVariantProposition.rst
+++ b/schema/va-spec/base/def/SubjectVariantProposition.rst
@@ -64,7 +64,7 @@ Some SubjectVariantProposition attributes are inherited from :ref:`Proposition`.
       - The relationship declared to hold between the subject and the object of the Proposition.
    *  - object
       -
-      - :ref:`Entity` | :ref:`iriReference`
+      - :ref:`Entity` | :ref:`ConceptSet` | :ref:`iriReference`
       - 1..1
       - An Entity or concept that is related to the subject of a Proposition via its predicate.
    *  - subjectVariant

--- a/schema/va-spec/base/def/SubjectVariantProposition.rst
+++ b/schema/va-spec/base/def/SubjectVariantProposition.rst
@@ -64,7 +64,7 @@ Some SubjectVariantProposition attributes are inherited from :ref:`Proposition`.
       - The relationship declared to hold between the subject and the object of the Proposition.
    *  - object
       -
-      - object
+      - :ref:`Entity` | :ref:`iriReference`
       - 1..1
       - An Entity or concept that is related to the subject of a Proposition via its predicate.
    *  - subjectVariant

--- a/schema/va-spec/base/def/TumorVariantFrequencyStudyResult.rst
+++ b/schema/va-spec/base/def/TumorVariantFrequencyStudyResult.rst
@@ -96,12 +96,12 @@ Some TumorVariantFrequencyStudyResult attributes are inherited from :ref:`StudyR
       - MUST be "TumorVariantFrequencyStudyResult".
    *  - sourceDataSet
       -
-      - :ref:`DataSet`
+      - :ref:`DataSet` | :ref:`iriReference`
       - 0..1
       - The dataset from which data in the Tumor Variant Frequency Study Result was taken.
    *  - focusVariant
       -
-      - :ref:`Allele` | :ref:`iriReference` | :ref:`CategoricalVariant`
+      - :ref:`Allele` | :ref:`CategoricalVariant` | :ref:`iriReference`
       - 1..1
       - The variant for which frequency data is reported in the Study Result.
    *  - affectedSampleCount
@@ -121,7 +121,7 @@ Some TumorVariantFrequencyStudyResult attributes are inherited from :ref:`StudyR
       - The frequency of tumor samples that include the focus variant in the sample group.
    *  - sampleGroup
       -
-      - :ref:`StudyGroup`
+      - :ref:`StudyGroup` | :ref:`iriReference`
       - 0..1
       - The set of samples about which the frequency data was generated.
    *  - subGroupFrequency

--- a/schema/va-spec/base/def/VariantPathogenicityProposition.rst
+++ b/schema/va-spec/base/def/VariantPathogenicityProposition.rst
@@ -84,11 +84,11 @@ Some VariantPathogenicityProposition attributes are inherited from :ref:`Genetic
       - The :ref:`Condition` or :ref:`ConditionSet`for which the variant impact is stated.
    *  - penetranceQualifier
       -
-      - :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - Reports the penetrance of the pathogenic effect - i.e. the extent to which the variant impact is expressed by individuals carrying it as a measure of the proportion of carriers exhibiting the condition.
    *  - modeOfInheritanceQualifier
       -
-      - :ref:`MappableConcept`
+      - :ref:`MappableConcept` | :ref:`iriReference`
       - 0..1
       - Reports a pattern of inheritance expected for the pathogenic effect of the variant. Consider using terms or codes from community terminologies here - e.g. terms from the 'Mode of inheritance' branch of the Human Phenotype Ontology such as HP:0000006 (autosomal dominant inheritance).

--- a/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
+++ b/schema/va-spec/base/json/CohortAlleleFrequencyStudyResult
@@ -94,7 +94,14 @@
          "default": "CohortAlleleFrequencyStudyResult"
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "The dataset from which the CohortAlleleFrequencyStudyResult was reported.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance. If use cases for this arise we can make this attribute take an array of DataSets."
       },
@@ -123,7 +130,14 @@
          "description": "The frequency of the focusAllele in the cohort."
       },
       "cohort": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/StudyGroup",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/StudyGroup"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "The cohort from which the frequency was derived."
       },
       "subCohortFrequency": {

--- a/schema/va-spec/base/json/ComputationalVariantFunctionalImpactAnalysisResult
+++ b/schema/va-spec/base/json/ComputationalVariantFunctionalImpactAnalysisResult
@@ -111,7 +111,14 @@
          "description": "Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of this Information Entity."
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "The dataset from which the in silico scores were retrieved or derived (e.g., an Ensembl VEP annotation dataset)."
       }
    },

--- a/schema/va-spec/base/json/Contribution
+++ b/schema/va-spec/base/json/Contribution
@@ -44,7 +44,14 @@
          "default": "Contribution"
       },
       "contributor": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Agent",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/Agent"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "The agent that made the contribution."
       },
       "activityType": {

--- a/schema/va-spec/base/json/CustomProposition
+++ b/schema/va-spec/base/json/CustomProposition
@@ -45,7 +45,7 @@
       },
       "customPropositionType": {
          "type": "string",
-         "description": "A user-defined subtype that distinguishes one kind of CustomProposition from another. Because all CustomPropositions share the same 'type' value (\"CustomProposition\"), this attribute plays the role that 'type' plays for standard Proposition subclasses - allowing consumers to discern the specific type of possible fact a given CustomProposition represents (e.g. \"GeneDiseaseValidityProposition\")."
+         "description": "A user-defined subtype that distinguishes one kind of CustomProposition from another. Because all CustomPropositions share the same 'type' value (\"CustomProposition\"), this attribute plays the role that 'type' plays for standard Proposition subclasses - allowing consumers to discern the specific type of possible fact a given CustomProposition represents (e.g. \"ClinvarDrugResponseProposition\")."
       },
       "subject": {
          "oneOf": [

--- a/schema/va-spec/base/json/CustomProposition
+++ b/schema/va-spec/base/json/CustomProposition
@@ -53,16 +53,19 @@
                "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
             },
             {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/ConceptSet"
+            },
+            {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             },
             {
-               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/MolecularVariation"
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Variation"
             }
          ],
-         "description": "A custom entity or concept that is the subject of the Proposition.",
+         "description": "A variant or concept that is the subject of the Proposition.",
          "$comment": "In profiles for most VA-Spec implementations, the subject will be a some type of genetic variation. However, the Core VA model is domain-agnostic, and supports Propositions about any type of Entity. Some data providers may want to make statements about other entities or concepts that represent evidence for a Propositions about genetic variation (e.g. a statement that a gene is valid for some disease is one type of evidence that may support the pathogenicity of a variant that affects that gene)."
       },
       "predicate": {
@@ -73,13 +76,22 @@
       "object": {
          "oneOf": [
             {
+               "$ref": "/ga4gh/schema/cat-vrs/1.1.0-ballot.2026-07.1/json/CategoricalVariant"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/ConceptSet"
+            },
+            {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
             },
             {
                "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            },
+            {
+               "$ref": "/ga4gh/schema/vrs/2.1.0-ballot.2026-07.1/json/Variation"
             }
          ],
-         "description": "A custom entity or concept that is the object of the Proposition.",
+         "description": "A variant or concept that is the object of the Proposition.",
          "$comment": "The object of a Proposition can be any Entity or concept that is related to the subject. When the subject is a genetic variation, the object is often a disease, phenotype, therapeutic intervention, or gene."
       },
       "qualifiers": {
@@ -95,10 +107,13 @@
                "value": {
                   "oneOf": [
                      {
-                        "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+                        "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
                      },
                      {
-                        "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+                        "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/ConceptSet"
+                     },
+                     {
+                        "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
                      }
                   ],
                   "description": "The value of the qualifier - either a MappableConcept or an IRI reference."

--- a/schema/va-spec/base/json/DataSet
+++ b/schema/va-spec/base/json/DataSet
@@ -72,9 +72,16 @@
          "$comment": "This property can capture version information for resources such as data sets and documents that get published and released as a unit for community use. These may go through rounds of revisions that add or modify content, but don\u2019t change the identity of the resource. Use this attribute in cases where version is not reflected in an identifier associated with the data set."
       },
       "license": {
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "A specific license that dictates legal permissions for how a data set can be used (by whom, where, for what purposes, with what additional requirements, etc.)",
-         "$comment": "Where possible, provide a URL pointing to the license or a description of it (e.g. \"https://creativecommons.org/licenses/by/4.0/\"). Otherwise, provide a free-text name or description of the license (e.g. \"CC-BY\").",
-         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+         "$comment": "Where possible, provide a URL pointing to the license or a description of it (e.g. \"https://creativecommons.org/licenses/by/4.0/\"). Otherwise, provide a free-text name or description of the license (e.g. \"CC-BY\")."
       }
    },
    "required": [

--- a/schema/va-spec/base/json/EvidenceLine
+++ b/schema/va-spec/base/json/EvidenceLine
@@ -81,7 +81,6 @@
          "default": "EvidenceLine"
       },
       "targetProposition": {
-         "description": "The possible fact against which evidence items contained in an Evidence Line were collectively evaluated, in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against a target proposition that the variant is pathogenic for a specific disease.",
          "oneOf": [
             {
                "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/CustomProposition"
@@ -112,8 +111,12 @@
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
-         ]
+         ],
+         "description": "The possible fact against which evidence items contained in an Evidence Line were collectively evaluated, in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based assessment of variant pathogenicity, the support provided by distinct lines of evidence are assessed against a target proposition that the variant is pathogenic for a specific disease."
       },
       "hasEvidenceItems": {
          "type": "array",

--- a/schema/va-spec/base/json/EvidenceLine
+++ b/schema/va-spec/base/json/EvidenceLine
@@ -150,17 +150,31 @@
          "description": "The direction of support that the Evidence Line is determined to provide toward its target Proposition (supports, disputes, neutral)"
       },
       "strengthOfEvidenceProvided": {
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "The strength of support that an Evidence Line is determined to provide for or against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided value.",
-         "$comment": "Values of this attribute can be defined by for a given profile based on domain/application needs, but should be framed in qualitative terms (e.g. 'strong', 'moderate', 'weak'). The 'scoreOfEvidenceProvided' attribute can be used to report quantitative assessments of evidence provided.",
-         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+         "$comment": "Values of this attribute can be defined by for a given profile based on domain/application needs, but should be framed in qualitative terms (e.g. 'strong', 'moderate', 'weak'). The 'scoreOfEvidenceProvided' attribute can be used to report quantitative assessments of evidence provided."
       },
       "scoreOfEvidenceProvided": {
          "type": "number",
          "description": "A quantitative score indicating the strength of support that an Evidence Line is determined to provide for or against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided value."
       },
       "evidenceOutcome": {
-         "description": "A term summarizing the overall outcome of the evidence assessment represented by the Evidence Line, in terms of the direction and strength of support it provides for or against the target Proposition.",
-         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
+         "description": "A term summarizing the overall outcome of the evidence assessment represented by the Evidence Line, in terms of the direction and strength of support it provides for or against the target Proposition."
       }
    },
    "required": [

--- a/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
+++ b/schema/va-spec/base/json/ExperimentalVariantFunctionalImpactStudyResult
@@ -110,7 +110,14 @@
          "$comment": "Examples: a specific experimental protocol or data analysis specification that describes how data were generated; an evidence interpretation guideline that describes steps taken to interpret data in making a variant pathogenicity classification; a method for using electron microscopy to image cell membrane proteins. Note that this attribute captures a specific *instance* of a specification or method (e.g. the specific electron microscopy method described in https://doi.org/10.1002/cpz1.1045) - as opposed to reporting a *type* of method applied (e.g. 'Transmission Electron Microscopy')."
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "The full data set that provided the reported the functional impact score.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance. If use cases for this arise we can make this attribute take an array of DataSets."
       }

--- a/schema/va-spec/base/json/Statement
+++ b/schema/va-spec/base/json/Statement
@@ -81,8 +81,6 @@
          "default": "Statement"
       },
       "proposition": {
-         "description": "A possible fact, the validity of which is assessed and reported by the Statement. A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the level of confidence/evidence supporting this claim.",
-         "$comment": "Statements put forth a Proposition that expresses some possible fact about the world, and may provide an assessment of this proposition\u2019s validity (i.e. how likely it is to be true or false based on evaluated evidence). The semantics of the Proposition are explicitly captured using subject, predicate, object, and optional qualifier attributes (SPOQ). An assessment of the Proposition\u2019s validity can optionally be captured using the Statement's direction, strength, and/or score attributes (DS).",
          "oneOf": [
             {
                "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/CustomProposition"
@@ -113,8 +111,13 @@
             },
             {
                "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/VariantTherapeuticResponseProposition"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
             }
-         ]
+         ],
+         "description": "A possible fact, the validity of which is assessed and reported by the Statement. A Statement can put forth the proposition as being true, false, or uncertain, and may provide an assessment of the level of confidence/evidence supporting this claim.",
+         "$comment": "Statements put forth a Proposition that expresses some possible fact about the world, and may provide an assessment of this proposition\u2019s validity (i.e. how likely it is to be true or false based on evaluated evidence). The semantics of the Proposition are explicitly captured using subject, predicate, object, and optional qualifier attributes (SPOQ). An assessment of the Proposition\u2019s validity can optionally be captured using the Statement's direction, strength, and/or score attributes (DS)."
       },
       "direction": {
          "description": "A term indicating whether the Statement supports, disputes, or remains neutral w.r.t. the validity of the Proposition it evaluates.",
@@ -129,7 +132,14 @@
       "strength": {
          "description": "A term used to report the strength of a Proposition's assessment in the direction indicated (i.e. how strongly supported or disputed the Proposition is believed to be).  Implementers may choose to frame a strength assessment in terms of how *confident* an agent is that the Proposition is true or false, or in terms of the *strength of all evidence* they believe supports or disputes it.",
          "$comment": "Statements put forth a Proposition that expresses some possible fact about the world, and may provide an assessment of this proposition's validity (i.e. how likely it is to be true or false based on evaluated evidence) using 'direction', 'strength', and 'score' attributes. The 'strength' attribute is used to report the strength of this assessment in the direction indicated. Strength can be framed as a *level of confidence* that the Proposition is true or false, or as a *level of evidence* that supports or disputes it. Data creators can define the permissible values for the 'strength' attribute to indicate which of these facets is being assessed (e.g. 'high confidence' vs 'low confidence', or 'strong evidence' vs 'weak evidence') - or they can choose values that don't commit to one or the other if they don't want to make the distinction (e.g. 'high' vs 'medium' vs 'low').",
-         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ]
       },
       "score": {
          "type": "number",
@@ -138,9 +148,16 @@
          "description": "A quantitative score that indicates the strength of a Proposition's assessment in the direction indicated (i.e. how strongly supported or disputed the Proposition is believed to be). Depending on its implementation, a score may reflect how *confident* that agent is that the Proposition is true or false, or the *strength of evidence* they believe supports or disputes it. Instructions for how to interpret the meaning of a given score may be gleaned from the method or document referenced in 'specifiedBy' attribute."
       },
       "classification": {
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "A single term or phrase summarizing the outcome of direction and strength assessments of a Statement's Proposition, in terms of a classification of its subject.",
-         "$comment": "Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice - and can be provided to report of a statement's conclusion in user-friendly terms. For example, in a Statement assessing the proposition that \"BRCA2 c.8023A>G is pathogenic for Breast Cancer\", and reporting a direction of 'supports' and strength of 'likely', the term  'likely pathogenic' from the ACMG Variant Interpretation Guidelines would be used as a subject classification.",
-         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+         "$comment": "Permissible values for this attribute are typically selected to be succinct and familiar in the target community of practice - and can be provided to report of a statement's conclusion in user-friendly terms. For example, in a Statement assessing the proposition that \"BRCA2 c.8023A>G is pathogenic for Breast Cancer\", and reporting a direction of 'supports' and strength of 'likely', the term  'likely pathogenic' from the ACMG Variant Interpretation Guidelines would be used as a subject classification."
       },
       "hasEvidenceLines": {
          "type": "array",

--- a/schema/va-spec/base/json/StudyGroup
+++ b/schema/va-spec/base/json/StudyGroup
@@ -53,7 +53,14 @@
       "characteristics": {
          "type": "array",
          "items": {
-            "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+            "oneOf": [
+               {
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+               },
+               {
+                  "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+               }
+            ]
          },
          "ordered": false,
          "description": "A feature or role shared by all members of the StudyGroup, representing a criterion for membership in the group.",

--- a/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
+++ b/schema/va-spec/base/json/TumorVariantFrequencyStudyResult
@@ -94,7 +94,14 @@
          "default": "TumorVariantFrequencyStudyResult"
       },
       "sourceDataSet": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/DataSet"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "The dataset from which data in the Tumor Variant Frequency Study Result was taken.",
          "$comment": "In most cases, a StudyResult will be generated using data from one source dataset - but it is possible multiple datasets related to a single study contain data about a particular focus that get collected into a single StudyResult instance. If use cases for this arise we can make this attribute take an array of DataSets."
       },
@@ -126,7 +133,14 @@
          "description": "The frequency of tumor samples that include the focus variant in the sample group."
       },
       "sampleGroup": {
-         "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/StudyGroup",
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/va-spec/1.1.0-ballot.2026-07.2/base/json/StudyGroup"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
          "description": "The set of samples about which the frequency data was generated."
       },
       "subGroupFrequency": {

--- a/schema/va-spec/base/json/VariantPathogenicityProposition
+++ b/schema/va-spec/base/json/VariantPathogenicityProposition
@@ -104,12 +104,26 @@
          "$comment": "The object of a Proposition can be any Entity or concept that is related to the subject. When the subject is a genetic variation, the object is often a disease, phenotype, therapeutic intervention, or gene."
       },
       "penetranceQualifier": {
-         "description": "Reports the penetrance of the pathogenic effect - i.e. the extent to which the variant impact is expressed by individuals carrying it as a measure of the proportion of carriers exhibiting the condition.",
-         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
+         "description": "Reports the penetrance of the pathogenic effect - i.e. the extent to which the variant impact is expressed by individuals carrying it as a measure of the proportion of carriers exhibiting the condition."
       },
       "modeOfInheritanceQualifier": {
-         "description": "Reports a pattern of inheritance expected for the pathogenic effect of the variant. Consider using terms or codes from community terminologies here - e.g. terms from the 'Mode of inheritance' branch of the Human Phenotype Ontology such as HP:0000006 (autosomal dominant inheritance).",
-         "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+         "oneOf": [
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/MappableConcept"
+            },
+            {
+               "$ref": "/ga4gh/schema/gks-core/1.2.0-ballot.2026-07.1/json/iriReference"
+            }
+         ],
+         "description": "Reports a pattern of inheritance expected for the pathogenic effect of the variant. Consider using terms or codes from community terminologies here - e.g. terms from the 'Mode of inheritance' branch of the Human Phenotype Ontology such as HP:0000006 (autosomal dominant inheritance)."
       }
    },
    "required": [

--- a/schema/va-spec/base/va-core-source.yaml
+++ b/schema/va-spec/base/va-core-source.yaml
@@ -130,7 +130,9 @@ $defs:
           in the study (e.g. 'exposure to nicotine' in an analysis correlating this variable with
           clinical outcomes).
       sourceDataSet:
-        $ref: "#/$defs/DataSet"
+        oneOf:
+          - $ref: "#/$defs/DataSet"
+          - $refCurie: gks.core:iriReference
         description: >-
           A larger DataSet from which the data included in the StudyResult was taken or derived.
         $comment: >-
@@ -181,7 +183,8 @@ $defs:
     heritableProperties:
       subject:
         oneOf:
-        - type: object
+          - $refCurie: gks.core:Entity
+          - $refCurie: gks.core:iriReference
         description: The Entity or concept about which the Proposition is made.
         $comment: >-
           In profiles for most VA-Spec implementations, the subject will be a some type of genetic
@@ -197,7 +200,8 @@ $defs:
           set of predicates for the relationships relevant in the domain.
       object:
         oneOf:
-        - type: object
+          - $refCurie: gks.core:Entity
+          - $refCurie: gks.core:iriReference
         description: An Entity or concept that is related to the subject of a Proposition via its predicate.
         $comment: >-
           The object of a Proposition can be any Entity or concept that is related to the subject. When the subject is a
@@ -381,7 +385,9 @@ $defs:
         default: Contribution
         description: MUST be "Contribution".
       contributor:
-        $ref: "#/$defs/Agent"
+        oneOf:
+          - $ref: "#/$defs/Agent"
+          - $refCurie: gks.core:iriReference
         description: >-
           The agent that made the contribution.
       activityType:
@@ -501,7 +507,9 @@ $defs:
         default: Statement
         description: MUST be "Statement".
       proposition:
-        $ref: "#/$defs/Proposition"
+        oneOf:
+          - $ref: "#/$defs/Proposition"
+          - $refCurie: gks.core:iriReference
         description:  >-
           A possible fact, the validity of which is assessed and reported by the Statement. A Statement can put forth the proposition as being
           true, false, or uncertain, and may provide an assessment of the level of confidence/evidence supporting this claim.
@@ -543,7 +551,9 @@ $defs:
           is being assessed (e.g. 'high confidence' vs 'low confidence', or 'strong evidence' vs 'weak evidence') -
           or they can choose values that don't commit to one or the other if they don't want to make the distinction
           (e.g. 'high' vs 'medium' vs 'low').
-        $refCurie: gks.core:MappableConcept
+        oneOf:
+          - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
       score:
         type: number
         maturity: draft
@@ -558,7 +568,9 @@ $defs:
           The 'score' attribute serves the same purpose as 'strength', but allows for a quantitative assessment based
           on a numerical score.
       classification:
-        $refCurie: gks.core:MappableConcept
+        oneOf:
+          - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: >-
           A single term or phrase summarizing the outcome of direction and strength
           assessments of a Statement's Proposition, in terms of a classification of
@@ -631,7 +643,9 @@ $defs:
         default: EvidenceLine
         description: MUST be "EvidenceLine".
       targetProposition:
-        $ref: "#/$defs/Proposition"
+        oneOf:
+          - $ref: "#/$defs/Proposition"
+          - $refCurie: gks.core:iriReference
         description: >-
           The possible fact against which evidence items contained in an Evidence Line were collectively evaluated,
           in determining the overall strength and direction of support they provide. For example, in an ACMG Guideline-based
@@ -741,7 +755,9 @@ $defs:
           revisions that add or modify content, but don’t change the identity of the resource. Use this
           attribute in cases where version is not reflected in an identifier associated with the data set.
       license:
-        $refCurie: gks.core:MappableConcept
+        oneOf:
+          - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: >-
           A specific license that dictates legal permissions for how a data set can be used
           (by whom, where, for what purposes, with what additional requirements, etc.)
@@ -988,13 +1004,17 @@ $defs:
           - $refCurie: gks.core:iriReference
         description: The :ref:`Condition` or :ref:`ConditionSet`for which the variant impact is stated.
       penetranceQualifier:
-        $refCurie: gks.core:MappableConcept
+        oneOf:
+          - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: >-
           Reports the penetrance of the pathogenic effect - i.e. the extent to which the
           variant impact is expressed by individuals carrying it as a measure of the
           proportion of carriers exhibiting the condition.
       modeOfInheritanceQualifier:
-        $refCurie: gks.core:MappableConcept
+        oneOf:
+          - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: >-
           Reports a pattern of inheritance expected for the pathogenic effect of the variant.
           Consider using terms or codes from community terminologies here - e.g. terms from the
@@ -1065,9 +1085,9 @@ $defs:
           is intended to respond to.
         extends: object
         oneOf:
-        - $ref: Therapy
-        - $ref: TherapyGroup
-        - $refCurie: gks.core:iriReference
+          - $ref: Therapy
+          - $ref: TherapyGroup
+          - $refCurie: gks.core:iriReference
       conditionQualifier:
         oneOf:
           - $ref: Condition
@@ -1149,7 +1169,9 @@ $defs:
         type: number
         description: The frequency of the focusAllele in the cohort.
       cohort:
-        $ref: "#/$defs/StudyGroup"
+        oneOf:
+          - $ref: "#/$defs/StudyGroup"
+          - $refCurie: gks.core:iriReference
         description: The cohort from which the frequency was derived.
       subCohortFrequency:
         type: array
@@ -1190,8 +1212,8 @@ $defs:
         description: The variant for which frequency data is reported in the Study Result.
         oneOf:
         - $refCurie: vrs:Allele
-        - $refCurie: gks.core:iriReference
         - $refCurie: cat-vrs:CategoricalVariant
+        - $refCurie: gks.core:iriReference
       affectedSampleCount:
         type: integer
         description: The number of tumor samples in the sample group that contain the focus variant.
@@ -1203,7 +1225,9 @@ $defs:
         type: number
         description: The frequency of tumor samples that include the focus variant in the sample group.
       sampleGroup:
-        $ref: "#/$defs/StudyGroup"
+        oneOf:
+          - $ref: "#/$defs/StudyGroup"
+          - $refCurie: gks.core:iriReference
         description: The set of samples about which the frequency data was generated.
       subGroupFrequency:
         type: array
@@ -1316,7 +1340,9 @@ $defs:
           $ref: "#/$defs/Contribution"
         description: Specific actions taken by an Agent toward the creation, modification, validation, or deprecation of this Information Entity.
       sourceDataSet:
-        $ref: "#/$defs/DataSet"
+        oneOf:
+          - $ref: "#/$defs/DataSet"
+          - $refCurie: gks.core:iriReference
         description: The dataset from which the in silico scores were retrieved or derived (e.g., an Ensembl VEP annotation dataset).
     required:
       - type

--- a/schema/va-spec/base/va-core-source.yaml
+++ b/schema/va-spec/base/va-core-source.yaml
@@ -258,7 +258,7 @@ $defs:
           Because all CustomPropositions share the same 'type' value ("CustomProposition"), this
           attribute plays the role that 'type' plays for standard Proposition subclasses - allowing
           consumers to discern the specific type of possible fact a given CustomProposition represents
-          (e.g. "GeneDiseaseValidityProposition").
+          (e.g. "ClinvarDrugResponseProposition").
       subject:
         extends: subject
         oneOf:

--- a/schema/va-spec/base/va-core-source.yaml
+++ b/schema/va-spec/base/va-core-source.yaml
@@ -116,6 +116,7 @@ $defs:
       focus:
         oneOf:
           - $refCurie: gks.core:Entity
+          - $refCurie: gks.core:ConceptSet
           - $refCurie: gks.core:iriReference
         description: >-
           The specific participant, subject or experimental unit in a Study that data included in the
@@ -184,6 +185,7 @@ $defs:
       subject:
         oneOf:
           - $refCurie: gks.core:Entity
+          - $refCurie: gks.core:ConceptSet
           - $refCurie: gks.core:iriReference
         description: The Entity or concept about which the Proposition is made.
         $comment: >-
@@ -201,6 +203,7 @@ $defs:
       object:
         oneOf:
           - $refCurie: gks.core:Entity
+          - $refCurie: gks.core:ConceptSet
           - $refCurie: gks.core:iriReference
         description: An Entity or concept that is related to the subject of a Proposition via its predicate.
         $comment: >-
@@ -259,20 +262,24 @@ $defs:
       subject:
         extends: subject
         oneOf:
-          - $refCurie: vrs:MolecularVariation
+          - $refCurie: vrs:Variation
           - $refCurie: cat-vrs:CategoricalVariant
           - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:ConceptSet
           - $refCurie: gks.core:iriReference
-        description: A custom entity or concept that is the subject of the Proposition.
+        description: A variant or concept that is the subject of the Proposition.
       predicate:
         extends: predicate
         description: A custom predicate that describes the relationship between the subject and object of the Proposition.
       object:
         extends: object
         oneOf:
-          - $refCurie: gks.core:iriReference
+          - $refCurie: vrs:Variation
+          - $refCurie: cat-vrs:CategoricalVariant
           - $refCurie: gks.core:MappableConcept
-        description: A custom entity or concept that is the object of the Proposition.
+          - $refCurie: gks.core:ConceptSet
+          - $refCurie: gks.core:iriReference
+        description: A variant or concept that is the object of the Proposition.
       qualifiers:
         type: array
         ordered: false
@@ -286,8 +293,9 @@ $defs:
                 information its value represents.
             value:
               oneOf:
-                - $refCurie: gks.core:iriReference
                 - $refCurie: gks.core:MappableConcept
+                - $refCurie: gks.core:ConceptSet
+                - $refCurie: gks.core:iriReference
               description: >-
                 The value of the qualifier - either a MappableConcept or an IRI reference.
           required:
@@ -680,7 +688,9 @@ $defs:
           The direction of support that the Evidence Line is determined to provide toward its target Proposition
           (supports, disputes, neutral)
       strengthOfEvidenceProvided:
-        $refCurie: gks.core:MappableConcept
+        oneOf:
+          - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: >-
           The strength of support that an Evidence Line is determined to provide for or against its target Proposition,
           evaluated relative to the direction indicated by the directionOfEvidenceProvided value.
@@ -695,7 +705,9 @@ $defs:
           against its target Proposition, evaluated relative to the direction indicated by the directionOfEvidenceProvided
           value.
       evidenceOutcome:
-        $refCurie: gks.core:MappableConcept
+        oneOf:
+          - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: >-
           A term summarizing the overall outcome of the evidence assessment represented by the Evidence Line, in terms of
           the direction and strength of support it provides for or against the target Proposition.
@@ -792,7 +804,9 @@ $defs:
       characteristics:
         type: array
         items:
-          $refCurie: gks.core:MappableConcept
+          oneOf:
+            - $refCurie: gks.core:MappableConcept
+            - $refCurie: gks.core:iriReference
         ordered: false
         description: >-
           A feature or role shared by all members of the StudyGroup, representing a criterion for
@@ -858,8 +872,8 @@ $defs:
       objectSequenceFeature:
         extends: object
         oneOf:
-          - $refCurie: gks.core:iriReference
           - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: >-
           The sequence feature (typically a gene or gene product) on whose function the impact
           of the subject variant is reported.
@@ -1308,18 +1322,18 @@ $defs:
         description: A descriptor indicating what the score represents (e.g., 'SIFT impact score', 'CADD Phred-scaled impact score').
       categoricalImpact:
         oneOf:
-          - $refCurie: gks.core:iriReference
           - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: The categorical interpretation derived from the score by the in silico tool (e.g., 'tolerated', 'benign', 'pathogenic').
       impactedFeatureType:
         oneOf:
-          - $refCurie: gks.core:iriReference
           - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: A descriptor indicating the type of feature for which the focus variant has a predicted impact
       impactedFeature:
         oneOf:
-          - $refCurie: gks.core:iriReference
           - $refCurie: gks.core:MappableConcept
+          - $refCurie: gks.core:iriReference
         description: The specific feature for which the focus variant has a predicted impact
       ancillaryResults:
         maturity: draft
@@ -1330,8 +1344,8 @@ $defs:
         additionalProperties: true
       specifiedBy:
         oneOf:
-          - $refCurie: gks.core:iriReference
           - $ref: "#/$defs/Method"
+          - $refCurie: gks.core:iriReference
         description: The in silico method or algorithm that was applied to generate the reported score(s).
       contributions:
         type: array

--- a/tests/fixtures/custom-proposition.yaml
+++ b/tests/fixtures/custom-proposition.yaml
@@ -1,36 +1,35 @@
 id: CustomProp001
 name: Example custom proposition
-description: A provider-defined proposition asserting that a gene is valid for a disease.
+description: >-
+  A provider-defined proposition, modeled by ClinVar as a ClinvarDrugResponseProposition,
+  asserting that a CFTR variant modulates response to the drug ivacaftor.
 type: CustomProposition
-customPropositionType: GeneDiseaseValidityProposition
-subject:
-  type: MappableConcept
-  id: hgnc:5173
-  conceptType: Gene
-  name: HRAS
-  primaryCoding:
-    code: HGNC:5173
-    system: https://www.genenames.org/
-    iris:
-      - https://identifiers.org/hgnc:5173
-predicate: isGeneticBasisFor
+customPropositionType: ClinvarDrugResponseProposition
+subject: https://www.ncbi.nlm.nih.gov/clinvar/variation/7108/
+predicate: hasDrugResponseFor
 object:
   type: MappableConcept
-  id: mondo:0009648
   conceptType: Disease
-  name: Costello syndrome
+  name: ivacaftor response
   primaryCoding:
-    code: MONDO:0009648
-    system: http://purl.obolibrary.org/obo/
+    code: CN236500
+    system: https://www.ncbi.nlm.nih.gov/medgen/
     iris:
-      - http://purl.obolibrary.org/obo/MONDO_0009648
+      - https://www.ncbi.nlm.nih.gov/medgen/CN236500
 qualifiers:
   - name: classification
     value:
       type: MappableConcept
-      name: Definitive
+      name: responsive
       primaryCoding:
-        code: definitive
-        system: https://www.clinicalgenome.org/
-  - name: modeOfInheritance
-    value: http://purl.obolibrary.org/obo/HP_0000006
+        code: drug-response
+        system: https://www.ncbi.nlm.nih.gov/clinvar/
+  - name: drug
+    value:
+      type: MappableConcept
+      name: ivacaftor
+      primaryCoding:
+        code: "1243041"
+        system: https://mor.nlm.nih.gov/RxNav/
+        iris:
+          - https://mor.nlm.nih.gov/RxNav/search?searchBy=RXCUI&searchTerm=1243041

--- a/tests/tu_coverage_exceptions.yaml
+++ b/tests/tu_coverage_exceptions.yaml
@@ -1,3 +1,8 @@
+va-spec.base:CustomProposition:
+  # Entity
+  - aliases
+  - extensions
+
 va-spec.base:ExperimentalVariantFunctionalImpactProposition:
   # Entity
   - name


### PR DESCRIPTION
## Summary

Addresses two pre-ballot schema issues on the `1.1.0-ballot.2026-07` line.

### #435 — CustomProposition datatype coverage
- Ports the `CustomProposition` class (draft maturity) onto this branch.
- Broadens `CustomProposition.subject` and `.object` to the full superset of datatypes used across standard proposition profiles: `vrs:Variation`, `cat-vrs:CategoricalVariant`, `gks.core:MappableConcept`, `gks.core:ConceptSet`, `gks.core:iriReference`.
- Adds `gks.core:ConceptSet` to the base `Proposition` subject/object, `StudyResult.focus`, and the CustomProposition qualifier value — giving custom propositions parity with standard profiles.
- Adds the `custom-proposition` test fixture plus `test_definitions` and `tu_coverage_exceptions` entries.

### #437 — Allow `iriReference` consistently
Add `gks.core:iriReference` as a `oneOf` option to attributes that reference inlineable objects, so implementers can reference instead of inline:
- `Contribution.contributor`
- `Statement.proposition`, `.strength`, `.classification`
- `EvidenceLine.targetProposition`, `.strengthOfEvidenceProvided`, `.evidenceOutcome`
- `StudyResult.sourceDataSet`, `CohortAlleleFrequencyStudyResult.cohort`, `TumorVariantFrequencyStudyResult.sampleGroup`
- `StudyGroup.characteristics`
- `DataSet.license`
- `ComputationalVariantFunctionalImpactAnalysisResult.sourceDataSet`
- `VariantPathogenicityProposition` penetrance/modeOfInheritance qualifiers

Also drops a stray top-level `$ref: DataSet` left beside the new `oneOf` on `StudyResult.sourceDataSet` (under draft 2020-12 sibling semantics it would have rejected an `iriReference` value, defeating the change).

## Verification
- `make all` regenerates cleanly.
- Full test suite passes (4 passed), including the new CustomProposition fixture.

## Open questions for reviewers
- **`StudyResult.focus`** had `gks.core:MappableConcept` removed from its `oneOf` (now `[Entity, ConceptSet, iriReference]`). Flagging in case that removal was unintended.
- **#439** (missing `Statement.confidence` / `EvidenceLine.confidenceOfEvidenceProvided`) is **not** yet included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)